### PR TITLE
Drop trivial reference to KCP

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -65,7 +65,3 @@ Each service that makes up StoneSoup is further explained in its own document.
 ### Naming Conventions
 
 - [Namespace Metadata](../ADR/adr-0010-namespace-metadata)
-
-### Control Plane
-
-- [KCP](../ref/kcp.md)


### PR DESCRIPTION
This should have been dropped in #23.

Related: https://github.com/redhat-appstudio/book/issues/51