### PR TITLE
ADR 22 Secret Management For User Workloads update

### DIFF
--- a/ADR/0022-secret-mgmt-for-user-workloads.md
+++ b/ADR/0022-secret-mgmt-for-user-workloads.md
@@ -74,9 +74,9 @@ metadata:
     name: upload-secret-data-for-remote-secret
     namespace: default
     labels:
-        spi.appstudio.redhat.com/upload-secret: remotesecret
+        appstudio.redhat.com/upload-secret: remotesecret
     annotations:
-        spi.appstudio.redhat.com/remotesecret-name: test-remote-secret
+        appstudio.redhat.com/remotesecret-name: test-remote-secret
 type: Opaque
 stringData:
     username: u


### PR DESCRIPTION
This PR addresses recent [discussions](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1681914904953249) , and keeps it updated with the current development process. Also related to https://github.com/redhat-appstudio/book/pull/68

New problems/cases
* It should be possible to distinguish in time the process of uploading confidential information and deploying it in the destination environment. For example, image-controller creates an image pull secret after `Component` is created and deploys it after `Environment` is made.
* It should be possible to set multiple destination targets.
* The UI should be able to search existing RemoteSecret by target environment/component/application.