### PR TITLE
feat: add a stale issues and prs pruner

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >-
+            This issue is stale because it has been open 90 days with no
+            activity.  Remove the `state/stale` label or comment, or this
+            will be closed in 30 days.
+          days-before-stale: 90
+          days-before-close: 30
+          stale-issue-label: 'state/stale'
+          stale-pr-label: 'state/stale'


### PR DESCRIPTION
Our PR queue includes some old items in an uncertain state.

Introduce this bot to help clear the queue in an impartial way.