### PR TITLE
Inherit theme from konflux-ci.dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/konflux-ci/architecture
 
 go 1.21.4
 
-require github.com/devcows/hugo-universal-theme v0.0.0-20240312142249-b34533c67125 // indirect
+require (
+	github.com/devcows/hugo-universal-theme v0.0.0-20240312142249-b34533c67125 // indirect
+	github.com/konflux-ci/konflux-ci.github.io/website/themes/konflux v0.0.0-20240509114905-d4077b01c954 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/devcows/hugo-universal-theme v0.0.0-20240312142249-b34533c67125 h1:J8y2CtVoD8DxOEoOEuQf3fmVKRErANEx4GPfDjdAWgA=
 github.com/devcows/hugo-universal-theme v0.0.0-20240312142249-b34533c67125/go.mod h1:MqYH15Evmut/wgYkFi7ArsX+k44HfRrH675FbVLBkq0=
+github.com/konflux-ci/konflux-ci.github.io/website/themes/konflux v0.0.0-20240509114905-d4077b01c954 h1:FZk9zuAZS+JVN0H0gTO22r9+55sSRvUEHPCEO/T15Yk=
+github.com/konflux-ci/konflux-ci.github.io/website/themes/konflux v0.0.0-20240509114905-d4077b01c954/go.mod h1:bOKbzWgz1nvEzVeJ0Ne+PsgvfMRYnuNpyw2FkUl3uTs=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,7 @@
 baseURL = 'http://localhost:1313/'
 languageCode = 'en-us'
 title = 'Standalone Konflux Architecture Docs'
-theme = 'github.com/devcows/hugo-universal-theme'
+theme = ['github.com/konflux-ci/konflux-ci.github.io/website/themes/konflux', 'github.com/devcows/hugo-universal-theme']
 
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"


### PR DESCRIPTION
This adds the theme from konflux-ci.dev as a Hugo module. Any styling changes there are applied to this website as well. The version is pinned, so updates to konflux-ci.dev will not be applied without running `hugo mod get -u`.