### PR TITLE
Use `relref` for links

### DIFF
--- a/content/architecture/HAS/hybrid-application-service-api.md
+++ b/content/architecture/HAS/hybrid-application-service-api.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The official Hybrid Application Service (HAS) APIs are listed in the Konflux [API Reference](https://redhat-appstudio.github.io/architecture/ref/application-environment-api.html#application).  The APIs Specific to HAS are:
+The official Hybrid Application Service (HAS) APIs are listed in the Konflux [API Reference]({{< relref "../../ref/application-environment-api.md#application" >}}).  The APIs Specific to HAS are:
 
-* [Application](https://redhat-appstudio.github.io/architecture/ref/application-environment-api.html#application)
-* [Component](https://redhat-appstudio.github.io/architecture/ref/application-environment-api.html#component)
-* [ComponentDetectionQuery](https://redhat-appstudio.github.io/architecture/ref/application-environment-api.html#componentdetectionquery)
+* [Application]({{< relref "../../ref/application-environment-api.md#application" >}})
+* [Component]({{< relref "../../ref/application-environment-api.md#component" >}})
+* [ComponentDetectionQuery]({{< relref "../../ref/application-environment-api.md#componentdetectionquery" >}})
 
 The topics below offer a more detailed explanation of the API usage with examples.
 
@@ -30,11 +30,11 @@ The topics below offer a more detailed explanation of the API usage with example
 
 ## References
 
-* [HAS Glossary](has-glossary.md)
+* [HAS Glossary]({{< relref "hybrid-application-service-glossary.md" >}})
 * [Sample Generated GitOpsRepo](https://github.com/jgwest/gitops-repository-template)
 
 
-### [Application CRD](hybrid-application-service-crds.md#application)
+### [Application CRD]({{% relref "hybrid-application-service-crds.md#application" %}}){#application-crd}
 
 #### Create Application
 <ul>
@@ -77,7 +77,7 @@ To delete an Application in HAS, simply delete the Application resource correspo
 
 </ul>
 
-### [Component CRD](hybrid-application-service-crds.md#component)
+### [Component CRD]({{% relref "hybrid-application-service-crds.md#component" %}}){#component-crd}
 
 #### Create Component
 <ul>
@@ -124,7 +124,7 @@ To delete a given Component in HAS, just delete its corresponding Component. The
 
 </ul>
 
-### [ComponentDetectionQuery CRD](hybrid-application-service-crds.md#componentdetectionquery)
+### [ComponentDetectionQuery CRD]({{% relref "hybrid-application-service-crds.md#componentdetectionquery" %}}){#componentdetectionquery-crd}
 
 #### Create ComponentDetectionQuery
 <ul>
@@ -164,5 +164,3 @@ targetPort will not have a default value, since it would be difficult to ascerta
 
 </ul>
 </ul>
-
-

--- a/content/architecture/HAS/hybrid-application-service-crds.md
+++ b/content/architecture/HAS/hybrid-application-service-crds.md
@@ -1,10 +1,10 @@
 # Hybrid Application Service (HAS) Kubernetes CRDs
 
-[Application](hybrid-application-service-crds.md#application)
+[Application]({{< relref "hybrid-application-service-crds.md#application" >}})
 
-[Component](hybrid-application-service-crds.md#component)
+[Component]({{< relref "hybrid-application-service-crds.md#component" >}})
 
-[ComponentDetectionQuery](hybrid-application-service-crds.md#componentdetectionquery)
+[ComponentDetectionQuery]({{< relref "hybrid-application-service-crds.md#componentdetectionquery" >}})
 
 ## Application
 The Application resource defines an Application in Konflux. The fields in the resource are relatively bare, just the name of the resource (a UUID), an annotation with the application’s name, a description for the Application, and its git repository.
@@ -154,28 +154,3 @@ When the Component is created, the HAS controller retrieves the component’s De
 |language|string| specifies the language of the Component detected                                                   | Java                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |projectType|string| specifies the type of project for the Component detected                                           | Spring                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 |componentStub|ComponentSpec| Stub of the Component CR detected with all the info gathered from the Devfile or service detection | <pre>Component Stub: <br/>Application:<br/>Container Image: <br/>Component Name:     java-springboot <br/>Env: <br/>  Name:    FOO <br/>  Value:   foo1 <br/>  Name:    BAR <br/>  Value:   bar1 <br/>Replicas:  1 <br/>Resources: <br/>  Limits: <br/>  Cpu:                  2 <br/>  Memory:               500Mi <br/>  Storage:              400Mi <br/>Requests: <br/>  Cpu:                  700m <br/>Route:                    route111 <br/>Source: <br/>  Git: <br/>  URL:      https://github.com/maysunfaisal/multi-components <br/>Target Port:  1111 <br/> |
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/content/architecture/HAS/hybrid-application-service-design.md
+++ b/content/architecture/HAS/hybrid-application-service-design.md
@@ -2,7 +2,7 @@
 
 ## Application CR Create
 
-Hybrid Application Console (HAC) collects the information required for creating Applications. An Application is a collection of one or more Components. Required information to be collected can be found in the [Hybrid Application Service (HAS) Kubernetes CRDs](hybrid-application-service-crds.md) doc. When all the Application information is available, HAC will create the Application CR to trigger the Application creation. The HAS Application CR Operator will:
+Hybrid Application Console (HAC) collects the information required for creating Applications. An Application is a collection of one or more Components. Required information to be collected can be found in the [Hybrid Application Service (HAS) Kubernetes CRDs]({{< relref "hybrid-application-service-crds.md" >}}) doc. When all the Application information is available, HAC will create the Application CR to trigger the Application creation. The HAS Application CR Operator will:
 1. Validate all the required fields in the Application CR
 2. If the Application model repository `spec.appModelRepository` and the GitOps repository `spec.gitOpsRepository` values are specified:
    1. It will be used for the Application model and GitOps repository.

--- a/content/architecture/_index.md
+++ b/content/architecture/_index.md
@@ -121,68 +121,67 @@ these resources.
 
 Each service that makes up Konflux is further explained in its own document.
 
-- [Hybrid Application Service](./hybrid-application-service/) - A workflow system that manages
+- [Hybrid Application Service]({{< relref "./hybrid-application-service.md" >}}) - A workflow system that manages
   the definition of the users' Application and Components.
-- [Build Service](./build-service/) - A workflow system that manages the build pipeline definition
+- [Build Service]({{< relref "./build-service.md" >}}) - A workflow system that manages the build pipeline definition
   for users' Components.
-- [Image Controller](./image-controller/) - A subsystem of the build-service that manages the
+- [Image Controller]({{< relref "./image-controller.md" >}}) - A subsystem of the build-service that manages the
   creation and access rights to OCI repositories.
-- [Java Rebuilds Service](./jvm-build-service/) - A subsystem of the build-service that manages
+- [Java Rebuilds Service]({{< relref "./jvm-build-service.md" >}}) - A subsystem of the build-service that manages
   the rebuild of binary java jars pulled from maven central for an improved degree of provenance.
-- [Integration Service](./integration-service/) - A workflow service that manages execution of
+- [Integration Service]({{< relref "./integration-service.md" >}}) - A workflow service that manages execution of
   users' tests and promotion in response to completing builds.
-- [Release Service](./release-service/) - A workflow service that manages execution of privileged
+- [Release Service]({{< relref "./release-service.md" >}}) - A workflow service that manages execution of privileged
   pipelines to release user content to protected destinations.
-- [GitOps Service](./gitops-service/) - A foundational service providing deployment of user
+- [GitOps Service]({{< relref "./gitops-service.md" >}}) - A foundational service providing deployment of user
   applications.
-- [Pipeline Service](./pipeline-service/) - A foundational service providing Pipeline APIs and secure supply
+- [Pipeline Service]({{< relref "./pipeline-service.md" >}}) - A foundational service providing Pipeline APIs and secure supply
   chain capabilities to other services
-- [Service Provider Integration](./service-provider-integration/) - A foundational service
+- [Service Provider Integration]({{< relref "./service-provider-integration.md" >}}) - A foundational service
   providing user secret management to other services.
-- [Enterprise Contract](./enterprise-contract/) - A specialized subsystem responsible for the
+- [Enterprise Contract]({{< relref "./enterprise-contract.md" >}}) - A specialized subsystem responsible for the
   definition and enforcement of policies related to how OCI artifacts are built and tested.
-- [Internal Services Controller](./internal-services/) - A specialized subsystem that enables
+- [Internal Services Controller]({{< relref "./internal-services.md" >}}) - A specialized subsystem that enables
   invoking services that are not network addressable.
 
 ## API References
 
 ### Developer Services
 
-- [Application and Environment API](../ref/application-environment-api/)
-- [Service Provider](../ref/service-provider.md)
-- [GitOps Service](../ref/gitops.md):
+- [Application and Environment API]({{< relref "../ref/application-environment-api.md" >}})
+- [Service Provider]({{< relref "../ref/service-provider.md" >}})
+- [GitOps Service]({{< relref "../ref/gitops.md" >}}):
 
 ### Naming Conventions
 
-- [Namespace Metadata](../ADR/adr-0010-namespace-metadata)
+- [Namespace Metadata]({{< relref "../decisions/0010-namespace-metadata.md" >}})
 
-[integration-service promotes OCI artifacts]: ../ADR/0016-integration-service-promotion-logic/
-[application-service]: ./hybrid-application-service/
-[pipeline-service]: ./pipeline-service/
-[gitops-service]: ./gitops-service/
-[build-service]: ./build-service/
-[integration-service]: ./integration-service/
-[release-service]: ./release-service/
-[internal-services]: ./internal-services/
-[Application]: ../ref/application-environment-api/#application
-[Applications]: ../ref/application-environment-api/#application
-[Component]: ../ref/application-environment-api/#component
-[Components]: ../ref/application-environment-api/#component
-[Environment]: ../ref/application-environment-api/#environment
-[Environments]: ../ref/application-environment-api/#environment
-[Snapshot]: ../ref/application-environment-api/#snapshot
-[Snapshots]: ../ref/application-environment-api/#snapshot
-[SnapshotEnvironmentBinding]: ../ref/application-environment-api/#snapshotenvironmentbinding
-[SnapshotEnvironmentBindings]: ../ref/application-environment-api/#snapshotenvironmentbinding
-[DeploymentTarget]: ../ref/application-environment-api/#deploymenttarget
-[DeploymentTargets]: ../ref/application-environment-api/#deploymenttarget
-[DeploymentTargetClaim]: ../ref/application-environment-api/#deploymenttargetclaim
-[DeploymentTargetClaims]: ../ref/application-environment-api/#deploymenttargetclaim
-[Release]: ../ref/release-service.html#release
-[Releases]: ../ref/release-service.html#release
-[ReleasePlan]: ../ref/release-service.html#releaseplan
-[ReleasePlans]: ../ref/release-service.html#releaseplan
-[ReleasePlanAdmission]: ../ref/release-service.html#releaseplanadmission
-[ReleasePlanAdmissions]: ../ref/release-service.html#releaseplanadmission
-[IntegrationTestScenario]: ../ref/integration-service.html#integrationtestscenario
-[IntegrationTestScenarios]: ../ref/integration-service.html#integrationtestscenario
+[integration-service promotes OCI artifacts]: {{< relref "../decisions/0016-integration-service-promotion-logic.md" >}}
+[application-service]: {{< relref "./hybrid-application-service.md" >}}
+[pipeline-service]: {{< relref "./pipeline-service.md" >}}
+[gitops-service]: {{< relref "./gitops-service.md" >}}
+[build-service]: {{< relref "./build-service.md" >}}
+[integration-service]: {{< relref "./integration-service.md" >}}
+[release-service]: {{< relref "./release-service.md" >}}
+[Application]: {{< relref "../ref/application-environment-api.md#application" >}}
+[Applications]: {{< relref "../ref/application-environment-api.md#application" >}}
+[Component]: {{< relref "../ref/application-environment-api.md#component" >}}
+[Components]: {{< relref "../ref/application-environment-api.md#component" >}}
+[Environment]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[Environments]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[Snapshot]: {{< relref "../ref/application-environment-api.md#snapshot" >}}
+[Snapshots]: {{< relref "../ref/application-environment-api.md#snapshot" >}}
+[SnapshotEnvironmentBinding]: {{< relref "../ref/application-environment-api.md#snapshotenvironmentbinding" >}}
+[SnapshotEnvironmentBindings]: {{< relref "../ref/application-environment-api.md#snapshotenvironmentbinding" >}}
+[DeploymentTarget]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTargets]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTargetClaim]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClaims]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[Release]: {{< relref "..//ref/release-service.md#release" >}}
+[Releases]: {{< relref "..//ref/release-service.md#release" >}}
+[ReleasePlan]: {{< relref "..//ref/release-service.md#releaseplan" >}}
+[ReleasePlans]: {{< relref "..//ref/release-service.md#releaseplan" >}}
+[ReleasePlanAdmission]: {{< relref "..//ref/release-service.md#releaseplanadmission" >}}
+[ReleasePlanAdmissions]: {{< relref "..//ref/release-service.md#releaseplanadmission" >}}
+[IntegrationTestScenario]: {{< relref "..//ref/integration-service.md#integrationtestscenario" >}}
+[IntegrationTestScenarios]: {{< relref "..//ref/integration-service.md#integrationtestscenario" >}}

--- a/content/architecture/build-service.md
+++ b/content/architecture/build-service.md
@@ -3,18 +3,18 @@
 
 ## Overview
 
-The Build Service is composed of controllers that create and configure build pipelines. The main input for the Build Service is a Component CR managed by the [Hybrid Application Service (HAS)](hybrid-application-service.md).
+The Build Service is composed of controllers that create and configure build pipelines. The main input for the Build Service is a Component CR managed by the [Hybrid Application Service (HAS)]({{< relref "hybrid-application-service.md" >}}).
 
 ![](../diagrams/build-service/build-service.drawio.svg)
 
 ### Dependencies
 
 The Build Service is dependent on the following services:
-- [Pipeline Service](./pipeline-service.md)
+- [Pipeline Service]({{< relref "./pipeline-service.md" >}})
   - Pipeline execution, Pipeline logging
-- [Hybrid Application Service](./hybrid-application-service.md)
+- [Hybrid Application Service]({{< relref "./hybrid-application-service.md" >}})
   - Provides Component CR with annotations and `.status.devfile` which is used for PipelineRun configuration.
-- [Image Controller](./image-controller.md)
+- [Image Controller]({{< relref "./image-controller.md" >}})
   - Generation of a container image repository and robot account for Component CR which is used by PipelineRun
 
 ## Controllers
@@ -56,7 +56,7 @@ Custom Mode:
 
 #### PipelineRun selection
 
-The Build Service owns [BuildPipelineSelector CRD](https://redhat-appstudio.github.io/architecture/ref/build-service.html#buildpipelineselector) which defines which PipelineRun to select for the Component CR. By default global BuildPipelineSelector `build-pipeline-selector` in `build-service` namespace is used. BuildPipelineSelector CR contains selectors, the first matching selector is used for the Component CR. The list of selectors can be extended by creating BuildPipelineSelector CR with the same name as the Application CR in the user's namespace. This will ensure that it is applied to Component CRs under the corresponding Application CR. The list of selectors can be also extended for the whole user namespace by creating BuildPipelineSelector CR named `build-pipeline-selector` in the user's namespace.
+The Build Service owns [BuildPipelineSelector CRD]({{< relref "../ref/build-service.md#buildpipelineselector" >}}) which defines which PipelineRun to select for the Component CR. By default global BuildPipelineSelector `build-pipeline-selector` in `build-service` namespace is used. BuildPipelineSelector CR contains selectors, the first matching selector is used for the Component CR. The list of selectors can be extended by creating BuildPipelineSelector CR with the same name as the Application CR in the user's namespace. This will ensure that it is applied to Component CRs under the corresponding Application CR. The list of selectors can be also extended for the whole user namespace by creating BuildPipelineSelector CR named `build-pipeline-selector` in the user's namespace.
 
 Selectors are processed in this order:
 - BuildPipelineSelector CR with the same name as Application CR in the user's namespace

--- a/content/architecture/enterprise-contract.md
+++ b/content/architecture/enterprise-contract.md
@@ -57,7 +57,7 @@ perform the EC policy validation, which it does as follows:
 
 The ec-cli also supports other related functions. For more information on
 ec-cli refer to the
-[documentation](https://enterprise-contract.github.io/ec-cli/main/reference.html)
+[documentation](https://enterprisecontract.dev/docs/ec-cli/main/index.html)
 and the [code](https://github.com/enterprise-contract/ec-cli).
 
 ### EC Task Definition
@@ -80,7 +80,7 @@ You can view the source code for the ECP CRD
 [here](https://github.com/enterprise-contract/enterprise-contract-controller) and
 see its documentation [here](https://enterprise-contract.github.io/ecc/main/).
 See also the related
-[API Reference](https://redhat-appstudio.github.io/architecture/ref/enterprise-contract.html)
+[API Reference]({{< relref "../ref/enterprise-contract.md" >}})
 
 ### EC Policies
 
@@ -131,9 +131,9 @@ service or on-demand.
 Additional Resources
 --------------------
 
-- [Konflux Documentation](https://redhat-appstudio.github.io/docs.appstudio.io)
+- [Konflux Documentation](https://konflux-ci.dev/)
 - [Enterprise Contract Documentation](https://enterprise-contract.github.io/)
-- [Architecture of Konflux](https://redhat-appstudio.github.io/architecture/)
+- [Architecture of Konflux](https://konflux-ci.dev/architecture/)
 
 
 

--- a/content/architecture/hybrid-application-service.md
+++ b/content/architecture/hybrid-application-service.md
@@ -15,7 +15,7 @@ Hybrid Application Service (HAS) provides an abstract way to define Applications
 
 
 ## Architecture Overview
-To see how HAS fits into the Konflux architecture, refer to the Konflux [Application Context](./index.md#application-context).
+To see how HAS fits into the Konflux architecture, refer to the Konflux [Application Context]({{< relref "./index.md#application-context)." >}}
 
 The diagram below shows the interaction between HAC and HAS services for the creation of Application and Component.
 
@@ -31,9 +31,9 @@ The diagram below shows the interaction between HAC and HAS services for the cre
 
 Navigate the various Hybrid Application Service topics to read more about them.
 
-- [Hybrid Application Service (HAS) Design](./HAS/hybrid-application-service-design.md)
-- [Hybrid Application Service (HAS) Glossary](./HAS/hybrid-application-service-glossary.md)
-- [Hybrid Application Service (HAS) Kubernetes API](./HAS/hybrid-application-service-api.md)
-- [Hybrid Application Service (HAS) Kubernetes CRDs](./HAS/hybrid-application-service-crds.md)
-- [Component Detection Query (CDQ) Controller Logic](./HAS/component-detection-query-controller-logic.md)
-- [Hybrid Application Service (HAS) Component Types](./HAS/hybrid-application-service-component-types.md)
+- [Hybrid Application Service (HAS) Design]({{< relref "./HAS/hybrid-application-service-design.md" >}})
+- [Hybrid Application Service (HAS) Glossary]({{< relref "./HAS/hybrid-application-service-glossary.md" >}})
+- [Hybrid Application Service (HAS) Kubernetes API]({{< relref "./HAS/hybrid-application-service-api.md" >}})
+- [Hybrid Application Service (HAS) Kubernetes CRDs]({{< relref "./HAS/hybrid-application-service-crds.md" >}})
+- [Component Detection Query (CDQ) Controller Logic]({{< relref "./HAS/component-detection-query-controller-logic.md" >}})
+- [Hybrid Application Service (HAS) Component Types]({{< relref "./HAS/hybrid-application-service-component-types.md" >}})

--- a/content/architecture/image-controller.md
+++ b/content/architecture/image-controller.md
@@ -3,7 +3,7 @@
 # Overview
 Image controller sets up and manages container image repositories for an application's components. This enables greater component isolation within Konflux where each component has its own image repository and secret for pushing images built via Konflux.
 
-The image controller can perform three actions on image repositories by watching for either specific annotation changes or deletion events of a [Component CR](https://redhat-appstudio.github.io/architecture/ref/application-environment-api.html#component):
+The image controller can perform three actions on image repositories by watching for either specific annotation changes or deletion events of a [Component CR]({{< relref "../ref/application-environment-api.md#component" >}}):
 
 - **Setup image repository**: Image controller creates an image repository for the Component CR in a remote image registry as well as a robot account which is specific to that repository for image push. A Kubernetes Secret object is also created with that robot account token in order to make it available for build PipelineRun.
 

--- a/content/architecture/integration-service.md
+++ b/content/architecture/integration-service.md
@@ -20,7 +20,7 @@ The Integration service uses the pipeline, snapshot, and environment controllers
 - When a build pipeline completes, Integration service creates a Snapshot CR representing a new collection of components that should be tested together.
 - When Integration Service sees a new Snapshot CR (created either by itself or by a user), it coordinates deployment of the application for testing. It does this by creating new “ephemeral” Konflux Environment CRs which trigger the GitOps Service to provision the ephemeral test environment.
 - After the environment is ready and the application snapshot has been deployed to it, Integration Service tests and validates the application according to user-provided configuration. It does this by executing Tekton PipelineRuns against the ephemeral test Environment.
-- Finally, if any automatic ReleasePlans have been created by the user in the workspace, it will create a Release CR signalling intent to release the tested content, to be carried out by the [release-service](./release-service.md).
+- Finally, if any automatic ReleasePlans have been created by the user in the workspace, it will create a Release CR signalling intent to release the tested content, to be carried out by the [release-service]({{< relref "./release-service.md" >}}).
 
 The diagram below shows the interaction of the integration service and other services.
 
@@ -28,18 +28,18 @@ The diagram below shows the interaction of the integration service and other ser
 
 ### Dependencies
 
-The [Integration Service](./integration-service.md) is dependent on the following services:
-- [Pipeline Service](./pipeline-service.md)
+The [Integration Service]({{< relref "./integration-service.md" >}}) is dependent on the following services:
+- [Pipeline Service]({{< relref "./pipeline-service.md" >}})
   - Pipeline execution, Pipeline logging
-- [GitOps Service](./gitops-service.md)
+- [GitOps Service]({{< relref "./gitops-service.md" >}})
   - Provides the facility to create
     - Snapshots defining sets of Builds to test
     - Environment to test the Application on
-- [Hybrid Application Service](./hybrid-application-service.md)
+- [Hybrid Application Service]({{< relref "./hybrid-application-service.md" >}})
   - Provides the Application and Component model. Integration Service updates the pullspec reference on the Component CR when a component passes its required testing.
-- [Release Service](./release-service.md)
+- [Release Service]({{< relref "./release-service.md" >}})
   - Provides the ReleasePlan that will be used to determine if integration-service should create a Release
-- [Enterprise Contract Service](./enterprise-contract.md)
+- [Enterprise Contract Service]({{< relref "./enterprise-contract.md" >}})
   - Provides facilities to validate whether content has passed the Enterprise Contract.
 
 

--- a/content/architecture/internal-services.md
+++ b/content/architecture/internal-services.md
@@ -13,7 +13,7 @@ The results and outcome of the pipeline are added as an update to the custom res
 
 ## System Context
 
-The diagram below shows the interaction of the internal services controller and the [Release Service](./release-service.md) and shows the flow of custom resources
+The diagram below shows the interaction of the internal services controller and the [Release Service]({{< relref "./release-service.md" >}}) and shows the flow of custom resources
 
 ![](../diagrams/internal-services/internal-services-controller-overview.jpg)
 

--- a/content/architecture/jvm-build-service.md
+++ b/content/architecture/jvm-build-service.md
@@ -20,17 +20,17 @@ JBS depends on Tekton, but is otherwise largely independent of the rest of Konfl
 
 ### Flow Overview
 
-The JVM Build service can be enabled on a specific namespace by creating a [`JBSConfig`](#JBSConfig) object, with `enableRebuilds: true` specified. This will trigger the controller to create a deployment of the local Cache in the namespace. This cache has a number of purposes, but the primary one is to cache artifacts from Maven central to speed up Java builds.
+The JVM Build service can be enabled on a specific namespace by creating a [`JBSConfig`](#jbsconfig) object, with `enableRebuilds: true` specified. This will trigger the controller to create a deployment of the local Cache in the namespace. This cache has a number of purposes, but the primary one is to cache artifacts from Maven central to speed up Java builds.
 
 Once it is enabled and the cache has started the JVM Build Service will watch for `PipelineRun` objects with the `JAVA_COMMUNITY_DEPENDENCIES` results. This will be present on end user builds that have dependencies from untrusted upstream sources.
 
 When one of these `PipelineRun` objects is observed JBS will extract the dependency list, and attempt to rebuild all the listed JVM artifacts from source.
 
-The first stage of this process is to create an [`ArtifactBuild`](#ArtifactBuild) object. This object represents a Maven `group:artifact:version` (GAV) coordinate of the library that needs to be built from source.
+The first stage of this process is to create an [`ArtifactBuild`](#artifactbuild) object. This object represents a Maven `group:artifact:version` (GAV) coordinate of the library that needs to be built from source.
 
 Once the `ArtifactBuild` object has been created JBS will then attempt to try and build it. This first step is to attempt to find the relevant source code.
 
-Once the source code location has been discovered a [`DependencyBuild`](#DependencyBuild) object is created. There are generally less `DependencyBuild` objects than there are `ArtifactBuild`, as multiple artifacts can come from the same build. The controller will then try and build the artifact, first it will run a build discovery pipeline, that attempts to determine possible ways of building the artifact. Once discovery is complete it uses this information to attempt to build the artifact in a trial and error manner.
+Once the source code location has been discovered a [`DependencyBuild`](#dependencybuild) object is created. There are generally less `DependencyBuild` objects than there are `ArtifactBuild`, as multiple artifacts can come from the same build. The controller will then try and build the artifact, first it will run a build discovery pipeline, that attempts to determine possible ways of building the artifact. Once discovery is complete it uses this information to attempt to build the artifact in a trial and error manner.
 
 The dependency discovery pipeline can check both configured shared repositories and the main repository
 (for example a Quay.io repository) for pre-existing builds. If a prior build is found, the pipeline will shortcut
@@ -200,4 +200,3 @@ spec:
 ### `SystemConfig`
 
 This is a singleton object that configures the JVM Build System. The main configuration it provides is the builder images to use.
-

--- a/content/architecture/pipeline-service.md
+++ b/content/architecture/pipeline-service.md
@@ -34,7 +34,7 @@ notable configurations:
 - The pruner (provided by the Pipelines operator) will be disabled in favor of
   pruning via Tekton Results.
 - Pipelines as Code will link the results of pipeline tasks to an appropriate
-  [Hybrid Application Console (HAC)](./hybrid-application-console.md) URL.
+  [Hybrid Application Console (HAC)]({{< relref "./hybrid-application-console.md" >}}) URL.
 
 ## Architecture
 

--- a/content/architecture/release-service.md
+++ b/content/architecture/release-service.md
@@ -98,22 +98,22 @@ The Release service will copy the annotations and labels from the Release CR and
 
 ### Dependencies
 
-The [Release Service](./release-service.md) is dependent on the following services:
-- [Pipeline Service](./pipeline-service.md)
+The [Release Service]({{< relref "./release-service.md" >}}) is dependent on the following services:
+- [Pipeline Service]({{< relref "./pipeline-service.md" >}})
     - Pipeline execution, Pipeline logging
-- [Integration Service](./integration-service.md)
+- [Integration Service]({{< relref "./integration-service.md" >}})
     - Facilitates automated testing of content produced by the build pipelines
-- [GitOps Service](./gitops-service.md)
+- [GitOps Service]({{< relref "./gitops-service.md" >}})
     - Provides the facility to create
         - Snapshots defining sets of Builds to release
         - Environment to deploy the Application to
         - SnapshotEnvironmentBindings to have the Snapshot of the Application deployed to a specific Environment
-- [Enterprise Contract Service](./enterprise-contract.md)
+- [Enterprise Contract Service]({{< relref "./enterprise-contract.md" >}})
     - Provides facilities to validate whether content has passed the Enterprise Contract.
 
 ## References
 
-[Enterprise Contract]: ./enterprise-contract.md
-[Integration Service]: ./integration-service.md
-[GitOps Service]: ./gitops-service.md
-[Pipeline Service]: ./pipeline-service.md
+[Enterprise Contract]: {{< relref "./enterprise-contract.md" >}}
+[Integration Service]: {{< relref "./integration-service.md" >}}
+[GitOps Service]: {{< relref "./gitops-service.md" >}}
+[Pipeline Service]: {{< relref "./pipeline-service.md" >}}

--- a/content/decisions/0001-pipeline-service-phase-1.md
+++ b/content/decisions/0001-pipeline-service-phase-1.md
@@ -10,7 +10,7 @@ Last Updated: 2023-09-29
 
 Obsolete
 
-Superceded by [ADR-0009](./0009-pipeline-service-via-operator.md)
+Superceded by [ADR-0009]({{< relref "./0009-pipeline-service-via-operator.md" >}})
 
 ## Context
 

--- a/content/decisions/0002-feature-flags.md
+++ b/content/decisions/0002-feature-flags.md
@@ -59,9 +59,9 @@ that would appreciate independence.
 
 Use “api discovery” to control the enablement of *individual* features in *individual* workspaces.
 
-[KCP] provides the [APIBinding] resource as a way of letting the user declare that a particular API
+KCP provides the APIBinding resource as a way of letting the user declare that a particular API
 (read: CRD) should be made available in a single workspace. The user installs something in their
-workspace by creating an [APIBinding]. Our processes (controllers and [hac]) should query for the
+workspace by creating an APIBinding. Our processes (controllers and [hac]) should query for the
 availability of a particular API they care about, and let their behavior be influenced by the
 existence or non-existence of that API.
 
@@ -93,10 +93,10 @@ can know that the [integration-service] features of HACBS are enabled in the wor
 
 - When generating a list of workspaces, [hac] could describe those workspaces as HACBS-enabled or
   not if one or more HACBS APIs are available via kubernetes API discovery in kcp. Those APIs will
-  be present if [APIBinding] objects are present in the workspace and have been handled by KCP.
+  be present if APIBinding objects are present in the workspace and have been handled by KCP.
 - When viewing an App Studio workspace, the [hac-dev] plugin should present the user with the
   corresponding HACBS view if one or more HACBS APIs are present in the workspace, which again will
-  be present if corresponding [APIBinding] objects have been created in the workspace and handled by
+  be present if corresponding APIBinding objects have been created in the workspace and handled by
   fulfilled by KCP.
 
 ## Open Questions
@@ -111,7 +111,7 @@ can know that the [integration-service] features of HACBS are enabled in the wor
 
 - We should experience a cleaner API - composable services, more aligned with a larger App Cloud API
   being developed by multiple teams.
-- We may find ourselves forced into creating a CRD (and corresponding [APIBinding]) just so that we
+- We may find ourselves forced into creating a CRD (and corresponding APIBinding) just so that we
   can influence the behavior of another service, just so we can give it a feature flag to check.
 - Services that change their behavior based on the existence or non-existence of APIs that they do
   not own need to take special care if they manage some off-cluster state.
@@ -127,17 +127,15 @@ can know that the [integration-service] features of HACBS are enabled in the wor
 
 Originally drafted in a [google document](https://docs.google.com/document/d/1KcXWZ8VGUg_iR0RjdGuDYedP8ZW63XCgF26KZUNgpeQ/edit)
 
-[hac]: ../architecture/hybrid-application-console.md
+[hac]: {{< relref "../architecture/hybrid-application-console.md" >}}
 [hac-dev]: https://github.com/openshift/hac-dev
-[has]: ../architecture/application-service.md
-[build-service]: ../architecture/build-service.md
-[integration-service]: ../architecture/integration-service.md
+[has]: {{< relref "../architecture/hybrid-application-service.md" >}}
+[build-service]: {{< relref "../architecture/build-service.md" >}}
+[integration-service]: {{< relref "../architecture/integration-service.md" >}}
 [customized pipelines]: https://issues.redhat.com/browse/HACBS-9
-[KCP]: ../ref/kcp.md
-[APIBinding]: ../ref/kcp.md#apibinding
-[Component]: ../ref/application-environment-api.md#component
-[ApplicationSnapshot]: ../ref/application-environment-api.md#applicationsnapshot
-[ApplicationSnapshots]: ref/application-environment-api.md#applicationsnapshot
-[ReleasePlan]: ../ref/release-service.md#releaseplan
-[ReleasePlans]: ../ref/release-service.md#releaseplan
-[IntegrationTestScenario]: ../ref/integration-service.md#integrationtestscenario
+[Component]: {{< relref "../ref/application-environment-api.md#component" >}}
+[ApplicationSnapshot]: {{< relref "../ref/application-environment-api.md#applicationsnapshot" >}}
+[ApplicationSnapshots]: {{< relref "ref/application-environment-api.md#applicationsnapshot" >}}
+[ReleasePlan]: {{< relref "../ref/release-service.md#releaseplan" >}}
+[ReleasePlans]: {{< relref "../ref/release-service.md#releaseplan" >}}
+[IntegrationTestScenario]: {{< relref "../ref/integration-service.md#integrationtestscenario" >}}

--- a/content/decisions/0003-interacting-with-internal-services.md
+++ b/content/decisions/0003-interacting-with-internal-services.md
@@ -34,7 +34,7 @@ one or more workspaces. This will be referred to as the **Internal Service Contr
 **Request** is used here as a general type meaning that real use cases might involve custom resources
 such as **ServiceABCRequest**.
 
-This strategy will make use of [KCP]'s VirtualWorkspace model allowing an internal service controller to watch a group of
+This strategy will make use of KCP's VirtualWorkspace model allowing an internal service controller to watch a group of
 workspace via a single _KUBECONFIG_. This internal service controller is expected to trigger a specific job that encapsulates the Internal Service's unit of work
 that HACBS wants to initiate. It is expected that the internal service controller should update the **status** of the **Request** CR to denote the progress of the
 triggered unit of work.
@@ -82,5 +82,4 @@ A proof of concept for the **Internal Services Controller** can be found [here](
 
 ---
 
-[KCP]: ../ref/kcp.md
-[release-service]: ../architecture/release-service.md
+[release-service]: {{< relref "../architecture/release-service.md" >}}

--- a/content/decisions/0006-log-conventions.md
+++ b/content/decisions/0006-log-conventions.md
@@ -29,7 +29,7 @@ For example:
 {"ts": "2023-03-07T11:32:29.020Z", "level": "info", "logger": "controllers.Component", "msg": "API Resource updated", "namespace": "samburrai-tenant", "audit": "true", "name": "go-net-http-hello-prqx", "controllerKind": "Component", "action": "UPDATE"}
 ```
 
-The **ts** field stands for "timestamp" (encoded as UTC/ISO-8601) and the meaning of log **level** should be self evident. The **logger** name helps your team understand which part of your service is emitting the log (usually `Log.WithName` from `zap`). The **msg** is a human readable string describing the event being logged. Further **json** key value pairs contain additional fields useful for searching. See full list of fields in the [Appendix](#Appendix).
+The **ts** field stands for "timestamp" (encoded as UTC/ISO-8601) and the meaning of log **level** should be self evident. The **logger** name helps your team understand which part of your service is emitting the log (usually `Log.WithName` from `zap`). The **msg** is a human readable string describing the event being logged. Further **json** key value pairs contain additional fields useful for searching. See full list of fields in the [Appendix](#appendix).
 
 The opinionated logging mechanism from the controller-runtime framework already conforms to this scheme. Care should be taken to make sure specific key/value pairs are logged.
 
@@ -168,7 +168,7 @@ func f() {
   form `<username>-tenant`. Today, it contains PII. As a part of the implementation work to align
   subsystems with this ADR we should include requests to update the scheme for naming new user
   workspaces to be something that does not include PII, for instance `<hash(username)>-tenant`. See
-  also [ADR 10](0010-namespace-metadata.html) and [ADR 12](0012-namespace-name-format.html).
+  also [ADR 10]({{< relref "0010-namespace-metadata.md" >}}) and [ADR 12]({{< relref "0012-namespace-name-format.md" >}}).
 
 ## Appendix
 

--- a/content/decisions/0007-change-management.md
+++ b/content/decisions/0007-change-management.md
@@ -9,8 +9,8 @@ number: 7
 
 Accepted
 
-* Relates to [ADR 17. Use our own pipelines](0017-use-our-pipelines.html)
-* Relates to [ADR 20. Source Retention](0020-source-retention.html)
+* Relates to [ADR 17. Use our own pipelines]({{< relref "0017-use-our-pipelines.md" >}})
+* Relates to [ADR 20. Source Retention]({{< relref "0020-source-retention.md" >}})
 
 ## Approvers
 

--- a/content/decisions/0008-environment-provisioning.md
+++ b/content/decisions/0008-environment-provisioning.md
@@ -7,7 +7,7 @@ number: 8
 
 ## Status
 
-Superceded by [ADR 32. Decoupling Deployment](0032-decoupling-deployment.html)
+Superceded by [ADR 32. Decoupling Deployment]({{< relref "0032-decoupling-deployment.md" >}})
 
 ## Approvers
 
@@ -457,15 +457,15 @@ spec:
 - [Original miro](https://miro.com/app/board/uXjVP77ztI4=)
 - [Issue tracking creation of this ADR (STONE-174)](https://issues.redhat.com/browse/STONE-174)
 
-[Environment]: ../ref/application-environment-api.md#environment
-[Environments]: ../ref/application-environment-api.md#environment
-[DT]: ../ref/application-environment-api.md#deploymenttarget
-[DTs]: ../ref/application-environment-api.md#deploymenttarget
-[DeploymentTarget]: ../ref/application-environment-api.md#deploymenttarget
-[DeploymentTargets]: ../ref/application-environment-api.md#deploymenttarget
-[DTC]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DTCs]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DeploymentTargetClaim]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DeploymentTargetClaims]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DeploymentTargetClass]: ../ref/application-environment-api.md#deploymenttargetclass
-[DeploymentTargetClasses]: ../ref/application-environment-api.md#deploymenttargetclass
+[Environment]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[Environments]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[DT]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DTs]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTarget]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTargets]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DTC]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DTCs]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClaim]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClaims]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClass]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}
+[DeploymentTargetClasses]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}

--- a/content/decisions/0009-pipeline-service-via-operator.md
+++ b/content/decisions/0009-pipeline-service-via-operator.md
@@ -52,7 +52,7 @@ the OSP CRDs. The following changes are specific to RHTAP:
 Furthermore, as the service will be accessed through CodeReadyToolchain (CRT), the
 following changes are also specific to RHTAP:
 - Deploying a proxy (known as `SprayProxy`) on the CRT host cluster that redirects
-  incoming PaC requests to the member clusters. More on SprayProxy [here](0031-sprayproxy.md).
+  incoming PaC requests to the member clusters. More on SprayProxy [here]({{< relref "0031-sprayproxy.md" >}}).
 - Providing a plugin to the CRT Proxy so Tekton Results requests are redirected
   to the appropriate member cluster.
 

--- a/content/decisions/0013-integration-service-api-contracts.md
+++ b/content/decisions/0013-integration-service-api-contracts.md
@@ -7,9 +7,9 @@ number: 13
 
 ## Status
 
-Deprecated by [ADR 30. Tekton Results Naming Convention](0030-tekton-results-naming-convention.html).
+Deprecated by [ADR 30. Tekton Results Naming Convention]({{< relref "0030-tekton-results-naming-convention.md" >}}).
 
-Relates to [ADR 14. Let Pipelines Proceed](0014-let-pipelines-proceed.html)
+Relates to [ADR 14. Let Pipelines Proceed]({{< relref "0014-let-pipelines-proceed.md" >}})
 
 ## Context
 

--- a/content/decisions/0014-let-pipelines-proceed.md
+++ b/content/decisions/0014-let-pipelines-proceed.md
@@ -12,9 +12,9 @@ number: 14
 Accepted
 
 Relates to:
-* [ADR 13. Konflux Test Stream - API contracts](0013-integration-service-api-contracts.html)
-* [ADR 30. Tekton Results Naming Convention](0030-tekton-results-naming-convention.html)
-* [ADR 32. Decoupling Deployment](0032-decoupling-deployment.html)
+* [ADR 13. Konflux Test Stream - API contracts]({{< relref "0013-integration-service-api-contracts.md" >}})
+* [ADR 30. Tekton Results Naming Convention]({{< relref "0030-tekton-results-naming-convention.md" >}})
+* [ADR 32. Decoupling Deployment]({{< relref "0032-decoupling-deployment.md" >}})
 
 ## Context
 
@@ -55,6 +55,6 @@ for users ([STONE-459]).
   unwritten principle. Documenting it here for posterity, visibility.
 
 [STONE-459]: https://issues.redhat.com/browse/STONE-459
-[Environments]: ../ref/application-environment-api.html#environment
-[ADR-0030]: 0030-tekton-results-naming-convention.html
-[enterprise contract]: ../architecture/enterprise-contract.html
+[Environments]: {{ relref "../ relref "../ref/application-environment-api.md#environment" }}" }}
+[ADR-0030]: {{< relref "0030-tekton-results-naming-convention.md" >}}
+[enterprise contract]: {{< relref "../architecture/enterprise-contract.md" >}}

--- a/content/decisions/0016-integration-service-promotion-logic.md
+++ b/content/decisions/0016-integration-service-promotion-logic.md
@@ -9,7 +9,7 @@ number: 16
 
 ## Status
 
-Superceded by [ADR 32. Decoupling Deployment](0032-decoupling-deployment.html)
+Superceded by [ADR 32. Decoupling Deployment]({{< relref "0032-decoupling-deployment.md" >}})
 
 ## Context
 
@@ -93,6 +93,6 @@ The promotion logic has originally been implemented as part of HACBS-802 / HACBS
 This document is created for posterity and visibility.
 
 [parentEnvironment]: https://github.com/redhat-appstudio/application-api/blob/5f554103549049bf02c1e344a13f0711081df6a1/api/v1alpha1/environment_types.go#L36-L39
-[Global Candidate List]: ../architecture/integration-service.html
+[Global Candidate List]: {{< relref "..//architecture/integration-service.md" >}}
 [HACBS-802]: https://issues.redhat.com/browse/HACBS-802
 [HACBS-801]: https://issues.redhat.com/browse/HACBS-801

--- a/content/decisions/0017-use-our-pipelines.md
+++ b/content/decisions/0017-use-our-pipelines.md
@@ -10,8 +10,8 @@ number: 17
 
 Accepted
 
-* Relates to [ADR 7. Change Management](0007-change-management.md)
-* Relates to [ADR 27. Container Image Management Practice](0027-container-images.md)
+* Relates to [ADR 7. Change Management]({{< relref "0007-change-management.md" >}})
+* Relates to [ADR 27. Container Image Management Practice]({{< relref "0027-container-images.md" >}})
 
 ## Context
 
@@ -44,6 +44,6 @@ start doing, but haven't made time to do so yet.
   and [Component] APIs.
 * This ADR supports [STONE-434](https://issues.redhat.com/browse/STONE-434).
 
-[integration-service]: ../ref/integration-service.html
-[Application]: ../ref/application-environment-api.html#application
-[Components]: ../ref/application-environment-api.html#component
+[integration-service]: {{< relref "..//ref/integration-service.md" >}}
+[Application]: {{< relref "..//ref/application-environment-api.md#application" >}}
+[Components]: {{< relref "..//ref/application-environment-api.md#component" >}}

--- a/content/decisions/0019-customize-url-github.md
+++ b/content/decisions/0019-customize-url-github.md
@@ -37,7 +37,7 @@ The following components in Konflux send data/results back to GitHub via the Che
 
 An Konflux workspace is associated with a Kubernetes namespace on a Konflux “member cluster”,
 which is not directly accessible by end users. The namespace name on the member cluster currently
-correlates with the workspace name (a suffix is added). [ADR 10](0010-namespace-metadata.html)
+correlates with the workspace name (a suffix is added). [ADR 10]({{< relref "0010-namespace-metadata.md" >}})
 specifies that a namespace label should exist which links the member cluster namespace back to the
 Konflux workspace.
 
@@ -72,7 +72,7 @@ permission to view the requested `PipelineRun` resource.
 ### Dev Sandbox: Member Cluster Labels
 
 Member cluster namespaces MUST have the `appstudio.redhat.com/workspace_name` label, in accordance
-with [ADR 10](0010-namespace-metadata.html).
+with [ADR 10]({{< relref "0010-namespace-metadata.md" >}}).
 
 ### Pipelines as Code: Customize URLs per Repository
 
@@ -114,4 +114,4 @@ source control repositories. This potential disclosure of identifying informatio
 presented to end users.
 
 This concern is mitigated if workspace names are changed to be an arbitrary string, or a hash of a
-known identifier (see [ADR 06](0006-log-conventions.html)).
+known identifier (see [ADR 06]({{< relref "0006-log-conventions.md" >}})).

--- a/content/decisions/0020-source-retention.md
+++ b/content/decisions/0020-source-retention.md
@@ -9,7 +9,7 @@ number: 20
 
 Accepted
 
-Relates to [ADR 7. Change Management](0007-change-management.html)
+Relates to [ADR 7. Change Management]({{< relref "0007-change-management.md" >}})
 
 ## Context
 
@@ -20,7 +20,7 @@ requirement."
 
 We intend for the Konflux pipeline to support this requirement in
 [RHTAP-107](https://issues.redhat.com/browse/RHTAP-107). Since we [Use our own pipelines (ADR
-.17)](0017-use-our-pipelines.html), this would satisfy the control for us, if it were implemented.
+.17)]({{< relref "0017-use-our-pipelines.md" >}}), this would satisfy the control for us, if it were implemented.
 
 So long as it is not yet implemented, we need a policy (an "administrative control" rather than
 a "technical control") that precribes how our own source repositories must be managed.

--- a/content/decisions/0022-secret-mgmt-for-user-workloads.md
+++ b/content/decisions/0022-secret-mgmt-for-user-workloads.md
@@ -13,7 +13,7 @@ Accepted
 
 Relates to:
 
-- [ADR 32. Decoupling Deployment](0032-decoupling-deployment.html)
+- [ADR 32. Decoupling Deployment]({{< relref "0032-decoupling-deployment.md" >}})
 
 ## Context
 

--- a/content/decisions/0023-git-references-to-furnish-integration-test-scenarios.md
+++ b/content/decisions/0023-git-references-to-furnish-integration-test-scenarios.md
@@ -79,7 +79,7 @@ enabling customers to test functionality and provide feedback during the develop
 use of bundle resolvers, if needed.
 
 
-[CR]: https://redhat-appstudio.github.io/architecture/ref/integration-service.html#integrationtestscenariospec
+[CR]: {{< relref "../ref/integration-service.md#integrationtestscenariospec" >}}
 [RHTAP-402]: https://issues.redhat.com/browse/RHTAP-402
 [PLNSRVCE-1030]: https://issues.redhat.com/browse/PLNSRVCE-1030
 [Tekton-resolvers]: https://tekton.dev/vault/pipelines-main/resolution/

--- a/content/decisions/0027-availability-probe-framework.md
+++ b/content/decisions/0027-availability-probe-framework.md
@@ -44,7 +44,7 @@ The availability Prometheus metric will be computed for each component based on 
 status of the latest execution of the CronJobs evaluating the component's availability.
 Component owners will provide the implementation for each component's CronJobs. By
 adhering to a specific standard
-([see naming convention below](#Probes-Naming-Convention)),
+([see naming convention below](#probes-naming-convention)),
 results will be aggregated into a standardized Prometheus metric to report on
 availability (i.e. component owners will not be required to provide the translation
 mechanism).

--- a/content/decisions/0027-container-images.md
+++ b/content/decisions/0027-container-images.md
@@ -9,7 +9,7 @@ number: 27
 
 Proposed
 
-* Relates to [ADR 17. Use our own pipelines](0017-use-our-pipelines.md)
+* Relates to [ADR 17. Use our own pipelines]({{< relref "0017-use-our-pipelines.md" >}})
 
 ## Context
 

--- a/content/decisions/0028-handling-snapshotenvironmentbinding-errors.md
+++ b/content/decisions/0028-handling-snapshotenvironmentbinding-errors.md
@@ -6,7 +6,7 @@ number: 28
 date: 2023-08-31T00:00:00Z
 
 ## Status
-Superceded by [ADR 32. Decoupling Deployment](0032-decoupling-deployment.html)
+Superceded by [ADR 32. Decoupling Deployment]({{< relref "0032-decoupling-deployment.md" >}})
 
 ## Context
 It is currently not possible to determine whether a SnapshotEnvironmentBinding (SEB) is stuck in an unrecoverable state.  This is a major problem when deciding if an ephemeral SEB needs to be cleaned up by the integration service's SnapshotEnvironmentBinding controller.  An inability to clean up errored SEBs can overload the cluster.

--- a/content/decisions/0029-component-dependencies.md
+++ b/content/decisions/0029-component-dependencies.md
@@ -179,5 +179,5 @@ Think about branches:
 * Since more PRs will trigger more PipelineRuns, our current PVC quota issues (which limit how many PipelineRuns can be run at any one time) may be exacerbated.
 * Users may have only a few Components, or they may have many (many dozens) of Components. Once they get past so many component dependencies, we suspect that users will likely change from checking that all dependent images work with the new parent image to "sharing" the verification load: building the image and pushing it out for other components/dependencies to update and test within their own PRs. With this design, the user can achieve this by purging the `build-nudges-ref` field values from their Component CRs. The parent image will be built and tested as normal. [build-service] will not send PRs. The user can still hypothethically construct their own PR Group to test a particular layered component on an unmerged parent image change.
 
-[build-service]: ../ref/build-service.md
-[integration-service]: ../ref/integration-service.md
+[build-service]: {{< relref "../ref/build-service.md" >}}
+[integration-service]: {{< relref "../ref/integration-service.md" >}}

--- a/content/decisions/0030-tekton-results-naming-convention.md
+++ b/content/decisions/0030-tekton-results-naming-convention.md
@@ -10,25 +10,25 @@ number: 30
 Accepted
 
 Relates to:
-* [ADR 13. Konflux Test Stream - API contracts](0013-integration-service-api-contracts.html)
-* [ADR 14. Let Pipelines Proceed](0014-let-pipelines-proceed.html)
+* [ADR 13. Konflux Test Stream - API contracts]({{< relref "0013-integration-service-api-contracts.md" >}})
+* [ADR 14. Let Pipelines Proceed]({{< relref "0014-let-pipelines-proceed.md" >}})
 
 ## Context
 
-In order to [Let Pipelines Proceed](0014-let-pipelines-proceed.html), the default interface of a Tekton Task's status code becomes an unsuitable API contract for communicating the successes and failures of tasks. [ADR 13. Konflux Test Stream - API contracts](0013-integration-service-api-contracts.html) established the first API contract for Tekton result standardization within Konflux for the built-in Task definitions when task failure was not an option. As Konflux onboarding continues, more non-default tasks (partner and user tasks, for example) will be defined and the current standardization's narrow scope may start to confuse task authors. Further compounding this issue is the lack of a concrete guidance or standard from the Tekton community around standard sets of result names. Therefore, the Konflux components should adhere to generic standards for supported results types while still enabling the platform to operate within the Tekton result size limitations.
+In order to [Let Pipelines Proceed]({{< relref "0014-let-pipelines-proceed.md" >}}), the default interface of a Tekton Task's status code becomes an unsuitable API contract for communicating the successes and failures of tasks. [ADR 13. Konflux Test Stream - API contracts]({{< relref "0013-integration-service-api-contracts.md" >}}) established the first API contract for Tekton result standardization within Konflux for the built-in Task definitions when task failure was not an option. As Konflux onboarding continues, more non-default tasks (partner and user tasks, for example) will be defined and the current standardization's narrow scope may start to confuse task authors. Further compounding this issue is the lack of a concrete guidance or standard from the Tekton community around standard sets of result names. Therefore, the Konflux components should adhere to generic standards for supported results types while still enabling the platform to operate within the Tekton result size limitations.
 
 ## Decision
 
 The following decision holds for all Pipeline Tasks denoted as must succeed in the build pipeline
 
 > All scanning and linting TaskRuns should *succeed* even if they find problems in the content they
-are evaluating. [[ADR-0014](0014-let-pipelines-proceed.html)]
+are evaluating. [[ADR-0014]({{< relref "0014-let-pipelines-proceed.md" >}})]
 
 If tasks exist outside of the build pipeline, they _may_ adhere to the following decisions or they may fall back to the status (failing or succeeding) of a TaskRun.
 
 There are two defined standards for minimized [Tekton result](https://tekton.dev/docs/pipelines/tasks/#emitting-results) formats based on the common task types -- test-like and scan-like tasks. Each of these standards will have a unique result name as well as their own result format.
 
-The standards presented in this ADR supersede those in [ADR 13. Konflux Test Stream - API contracts](0013-integration-service-api-contracts.html). All other standards presented in the previous ADR hold unless _this_ ADR is superseded by an additional ADR that deprecates those standards. These other non-deprecated standards presented include [Detailed Conftest Output JSON](0013-integration-service-api-contracts.html#detailed-conftest-output-json), [Information injection](0013-integration-service-api-contracts.html#information-injection), [Information format](0013-integration-service-api-contracts.html#information-format), and [Image references](0013-integration-service-api-contracts.html#image-references).
+The standards presented in this ADR supersede those in [ADR 13. Konflux Test Stream - API contracts]({{< relref "0013-integration-service-api-contracts.md" >}}). All other standards presented in the previous ADR hold unless _this_ ADR is superseded by an additional ADR that deprecates those standards. These other non-deprecated standards presented include [Detailed Conftest Output JSON]({{< relref "0013-integration-service-api-contracts.md#detailed-conftest-output-json" >}}), [Information injection]({{< relref "0013-integration-service-api-contracts.md#information-injection" >}}), [Information format]({{< relref "0013-integration-service-api-contracts.md#information-format" >}}), and [Image references]({{< relref "0013-integration-service-api-contracts.md#image-references" >}}).
 
 ### Results for Test-like Tasks
 Test-like tasks are those whose results can be immediately classified as successful or failed. If these tests are taken into account in the final suitability of an artifact for promotion or release, then all pass/fail determination would be deferred to the task run.

--- a/content/decisions/0032-decoupling-deployment.md
+++ b/content/decisions/0032-decoupling-deployment.md
@@ -13,14 +13,14 @@ Accepted
 
 Relates to:
 
-- [ADR 14. Let Pipelines Proceed](0014-let-pipelines-proceed.html)
-- [ADR 22. Secret Management for User Workloads](0022-secret-mgmt-for-user-workloads.html)
+- [ADR 14. Let Pipelines Proceed]({{< relref "0014-let-pipelines-proceed.md" >}})
+- [ADR 22. Secret Management for User Workloads]({{< relref "0022-secret-mgmt-for-user-workloads.md" >}})
 
 Supercedes:
 
-- [ADR 08. Environment Provisioning](0008-environment-provisioning.html)
-- [ADR 16. Integration Service Promotion Logic](0016-integration-service-promotion-logic.html)
-- [ADR 28. Handling SnapshotEnvironmentBinding Errors](0028-handling-snapshotenvironmentbinding-errors.html)
+- [ADR 08. Environment Provisioning]({{< relref "0008-environment-provisioning.md" >}})
+- [ADR 16. Integration Service Promotion Logic]({{< relref "0016-integration-service-promotion-logic.md" >}})
+- [ADR 28. Handling SnapshotEnvironmentBinding Errors]({{< relref "0028-handling-snapshotenvironmentbinding-errors.md" >}})
 
 ## Authors
 
@@ -203,41 +203,41 @@ Some of these phases can be done at the same time.
 [Dynamic Resource Allocation APIs]: https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
 [renovatebot]: https://github.com/renovatebot/renovate
 [deployment-target-operator]: #
-[gitops-service]: ../ref/gitops-service.md
+[gitops-service]: {{< relref "../ref/gitops.md" >}}
 [push-to-registry]: https://github.com/redhat-appstudio/release-service-catalog/tree/main/pipelines/push-to-external-registry
 [application-api]: https://github.com/redhat-appstudio/application-api
-[application-service]: ../architecture/application-service.md
-[integration-service]: ../architecture/integration-service.md
-[release-service]: ../architecture/release-service.md
-[Application]: ../ref/application-environment-api.md#application
-[Applications]: ../ref/application-environment-api.md#application
-[Component]: ../ref/application-environment-api.md#component
-[Components]: ../ref/application-environment-api.md#component
-[Environment]: ../ref/application-environment-api.md#environment
-[Environments]: ../ref/application-environment-api.md#environment
-[GitOpsDeploymentManagedEnvironment]: ../ref/application-environment-api.md#GitOpsDeploymentManagedEnvironment
-[GitOpsDeploymentManagedEnvironments]: ../ref/application-environment-api.md#GitOpsDeploymentManagedEnvironment
-[SnapshotEnvironmentBinding]: ../ref/application-environment-api.md#snapshotenvironmentbinding
-[SnapshotEnvironmentBindings]: ../ref/application-environment-api.md#snapshotenvironmentbinding
-[Snapshot]: ../ref/application-environment-api.md#snapshot
-[Snapshots]: ../ref/application-environment-api.md#snapshot
-[Release]: ../ref/release-service.md#Release
-[Releases]: ../ref/release-service.md#Release
-[ReleasePlan]: ../ref/release-service.md#ReleasePlan
-[ReleasePlans]: ../ref/release-service.md#ReleasePlan
-[ReleasePlanAdmission]: ../ref/release-service.md#ReleasePlanAdmission
-[ReleasePlanAdmissions]: ../ref/release-service.md#ReleasePlanAdmission
-[IntegrationTestScenario]: ../ref/integration-service.md#IntegrationTestScenario
-[IntegrationTestScenarios]: ../ref/integration-service.md#IntegrationTestScenario
-[DT]: ../ref/application-environment-api.md#deploymenttarget
-[DTs]: ../ref/application-environment-api.md#deploymenttarget
-[DeploymentTarget]: ../ref/application-environment-api.md#deploymenttarget
-[DeploymentTargets]: ../ref/application-environment-api.md#deploymenttarget
-[DTC]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DTCs]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DeploymentTargetClaim]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DeploymentTargetClaims]: ../ref/application-environment-api.md#deploymenttargetclaim
-[DTCls]: ../ref/application-environment-api.md#deploymenttargetclass
-[DTClses]: ../ref/application-environment-api.md#deploymenttargetclass
-[DeploymentTargetClass]: ../ref/application-environment-api.md#deploymenttargetclass
-[DeploymentTargetClasses]: ../ref/application-environment-api.md#deploymenttargetclass
+[application-service]: {{< relref "../architecture/hybrid-application-service.md" >}}
+[integration-service]: {{< relref "../architecture/integration-service.md" >}}
+[release-service]: {{< relref "../architecture/release-service.md" >}}
+[Application]: {{< relref "../ref/application-environment-api.md#application" >}}
+[Applications]: {{< relref "../ref/application-environment-api.md#application" >}}
+[Component]: {{< relref "../ref/application-environment-api.md#component" >}}
+[Components]: {{< relref "../ref/application-environment-api.md#component" >}}
+[Environment]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[Environments]: {{< relref "../ref/application-environment-api.md#environment" >}}
+[GitOpsDeploymentManagedEnvironment]: {{< relref "../ref/application-environment-api.md#GitOpsDeploymentManagedEnvironment" >}}
+[GitOpsDeploymentManagedEnvironments]: {{< relref "../ref/application-environment-api.md#GitOpsDeploymentManagedEnvironment" >}}
+[SnapshotEnvironmentBinding]: {{< relref "../ref/application-environment-api.md#snapshotenvironmentbinding" >}}
+[SnapshotEnvironmentBindings]: {{< relref "../ref/application-environment-api.md#snapshotenvironmentbinding" >}}
+[Snapshot]: {{< relref "../ref/application-environment-api.md#snapshot" >}}
+[Snapshots]: {{< relref "../ref/application-environment-api.md#snapshot" >}}
+[Release]: {{< relref "../ref/release-service.md#Release" >}}
+[Releases]: {{< relref "../ref/release-service.md#Release" >}}
+[ReleasePlan]: {{< relref "../ref/release-service.md#ReleasePlan" >}}
+[ReleasePlans]: {{< relref "../ref/release-service.md#ReleasePlan" >}}
+[ReleasePlanAdmission]: {{< relref "../ref/release-service.md#ReleasePlanAdmission" >}}
+[ReleasePlanAdmissions]: {{< relref "../ref/release-service.md#ReleasePlanAdmission" >}}
+[IntegrationTestScenario]: {{< relref "../ref/integration-service.md#IntegrationTestScenario" >}}
+[IntegrationTestScenarios]: {{< relref "../ref/integration-service.md#IntegrationTestScenario" >}}
+[DT]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DTs]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTarget]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DeploymentTargets]: {{< relref "../ref/application-environment-api.md#deploymenttarget" >}}
+[DTC]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DTCs]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClaim]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DeploymentTargetClaims]: {{< relref "../ref/application-environment-api.md#deploymenttargetclaim" >}}
+[DTCls]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}
+[DTClses]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}
+[DeploymentTargetClass]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}
+[DeploymentTargetClasses]: {{< relref "../ref/application-environment-api.md#deploymenttargetclass" >}}

--- a/content/decisions/0033-enable-native-opentelemetry-tracing.md
+++ b/content/decisions/0033-enable-native-opentelemetry-tracing.md
@@ -34,7 +34,7 @@ We recommend using an OpenTelemetry Collector as the way to collect Konflux nati
 
 Other Tekton pieces that Konflux leverages such as [pipeline as code](https://pipelinesascode.com/), [chains](https://tekton.dev/docs/chains/) and [results](https://tekton.dev/docs/results/) will have to be instrumented separately and will require upstream changes, so they are out of scope for this ADR.
 
-Also, other Konflux services such as the [build service](https://github.com/redhat-appstudio/architecture/blob/main/architecture/build-service.md), [application service](https://github.com/redhat-appstudio/architecture/blob/main/architecture/hybrid-application-service.md) and [integration service](https://github.com/redhat-appstudio/architecture/blob/main/architecture/integration-service.md) will also require either automatic instrumentation or code based instrumentation and therefore are also out of scope for this ADR.
+Also, other Konflux services such as the [build service]({{< relref "../architecture/build-service.md" >}}), [application service]({{< relref "../architecture/hybrid-application-service.md" >}}) and [integration service]({{< relref "../architecture/integration-service.md" >}}) will also require either automatic instrumentation or code based instrumentation and therefore are also out of scope for this ADR.
 
 Any other type of instrumentation that isn't native will be addressed in a future ADR.
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -15,6 +15,9 @@ paginate = 10
 # not pluralize title pages by default
 pluralizelisttitles = false
 
+# use relative links by default
+relativeURLs = true
+
 [params]
     mainSections = ["architecture", "decisions"]
     disabled_logo = false


### PR DESCRIPTION
The benefit of using `ref`/`relref` is that broken links are detected at build time. The benefit of using `relref` is that links are relative, so files can be opened from the file system in the browser and still work.

I've used global search-replace a lot so mistakes could have been made, the only broken links that I could find are the links towards the missing fragments in the `/ref` (api docs), seems that the ADRs point to objects that are no longer present in the API.