### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/ADR/0021-partner-tasks.md
+++ b/ADR/0021-partner-tasks.md
@@ -18,7 +18,7 @@ https://issues.redhat.com/browse/STONE-549
 
 ### Plumbing
 
-1. Setup a new Git high-level directory in https://github.com/redhat-appstudio/build-definitions for partners to contribute Tasks to.
+1. Setup a new Git high-level directory in https://github.com/konflux-ci/build-definitions for partners to contribute Tasks to.
 2. Define a directory structure for Task submissions as manifests in the yaml format.
 3. Configure a CI job that validates the Tasks upon opening of a pull request.
 4. Optionally, configure a CI job that generates an OCI artifact consumable in a Tekton Pipeline.
@@ -35,7 +35,7 @@ action to resolve the issue.
 #### Revoking a Task
 1. Open a PR to delete the Task.
 2. The Build/Test team reviews the PR and merges it.
-3. The Build/Test team updates the https://github.com/redhat-appstudio/build-definitions to remove references to the Task's OCI image whenever it is reasonable to do so.
+3. The Build/Test team updates the https://github.com/konflux-ci/build-definitions to remove references to the Task's OCI image whenever it is reasonable to do so.
 
 #### Definition of a valid Task
 
@@ -63,7 +63,7 @@ Component into StoneSoup, customize their Pipeline definition in the .tekton dir
 
 ## Alternatives
 
-* ~Use the github.com/redhat-appstudio/build-definitions for Task submissions by partners : This is being considered in the short-term, either way, the day-to-day operations will not quite change~ - this has been promoted to be the primary design.
+* ~Use the github.com/konflux-ci/build-definitions for Task submissions by partners : This is being considered in the short-term, either way, the day-to-day operations will not quite change~ - this has been promoted to be the primary design.
 * Use Tekton Hub for host Tasks : Tekton Hub is being deprecated.
 
 

--- a/ADR/0027-container-images.md
+++ b/ADR/0027-container-images.md
@@ -70,7 +70,7 @@ While our automation process will ensure that component teams are keeping their 
 
 #### End of Life Base Images (EOL)
 
-Component teams should be aware of the lifecycle policy for their base images by referring to the RedHat [Product Lifecycle page](https://access.redhat.com/product-life-cycles/update_policies).   Any base image version that is within 3 months of retiring must be updated to the latest patched major release. This should be supported by the [deprecated-base-image](https://github.com/redhat-appstudio/build-definitions/blob/main/task/deprecated-image-check/0.2/deprecated-image-check.yaml#L11-L12) check in the PAC pipeline.
+Component teams should be aware of the lifecycle policy for their base images by referring to the RedHat [Product Lifecycle page](https://access.redhat.com/product-life-cycles/update_policies).   Any base image version that is within 3 months of retiring must be updated to the latest patched major release. This should be supported by the [deprecated-base-image](https://github.com/konflux-ci/build-definitions/blob/main/task/deprecated-image-check/0.2/deprecated-image-check.yaml#L11-L12) check in the PAC pipeline.
 
 ***
 #### Exception Process

--- a/ADR/0033-enable-native-opentelemetry-tracing.md
+++ b/ADR/0033-enable-native-opentelemetry-tracing.md
@@ -10,7 +10,7 @@ Accepted
 
 ## Context
 
-Konflux is a tool under active development and, therefore, unforeseen issues may arise. A recent (at the time of writing this ADR) example is the [long running](https://github.com/redhat-appstudio/build-definitions/pull/856/checks?check_run_id=22307468968) [e2e-test](https://github.com/redhat-appstudio/build-definitions/blob/main/.tekton/tasks/e2e-test.yaml) in Konflux’s build definitions. Fixing and debugging such issues is not a trivial thing for Konflux’s developers. Additional data, metrics, telemetry and tracing are essential in enabling Konflux developers and SREs to come up with fixes.
+Konflux is a tool under active development and, therefore, unforeseen issues may arise. A recent (at the time of writing this ADR) example is the [long running](https://github.com/konflux-ci/build-definitions/pull/856/checks?check_run_id=22307468968) [e2e-test](https://github.com/konflux-ci/build-definitions/blob/main/.tekton/tasks/e2e-test.yaml) in Konflux’s build definitions. Fixing and debugging such issues is not a trivial thing for Konflux’s developers. Additional data, metrics, telemetry and tracing are essential in enabling Konflux developers and SREs to come up with fixes.
 
 Tracing, in particular, enables a straightforward model for dealing with complex, distributed systems. It gives unique insight into a system’s execution, grouping functions together. These grouping functions can be critical for finding fields that correlate to some problem, and provide powerful insights to reduce the range of possible causes.
 

--- a/architecture/index.md
+++ b/architecture/index.md
@@ -20,7 +20,7 @@ Konflux is a platform for building integrated software that streamlines, consoli
 - Build artifacts once that can be released to multiple locations, multiple use cases.
 - Specify builds and their dependencies entirely from git and not from transient state of the build system. Employ tools like [renovate](https://docs.renovatebot.com/) to manage dependency updates.
 - Build semantic reproducible artifacts. Any configuration which has the potential to affect the semantic functionality of a build should be source controlled and associated with the produced artifact (via the provenance, for example).
-- Be extensible. Provide opinionated [build pipelines](https://github.com/redhat-appstudio/build-definitions/) and [release pipelines](https://github.com/redhat-appstudio/release-service-catalog), but let users extend those and create their own.
+- Be extensible. Provide opinionated [build pipelines](https://github.com/konflux-ci/build-definitions/) and [release pipelines](https://github.com/redhat-appstudio/release-service-catalog), but let users extend those and create their own.
 - "Shift left" the decisions for releasing into PRs; you should be able to release artifacts from a PR as soon as it is merged.
 - Just in time scaling: In contrast to “just in case” scaling. The system should be able to scale without capacity reserved ahead of time.
 - Static stability: the overall system continues to work when a dependency is impaired.

--- a/tools/security-tools.MD
+++ b/tools/security-tools.MD
@@ -34,7 +34,7 @@ $ docker run --rm -i ghcr.io/hadolint/hadolint < Dockerfile
 - Check these [docs](https://quay.github.io/clair/howto/deployment.html) to understand the deployment models Clair currently uses.
 - For teams using quay.io as their container image registry, we enjoy the benefit of these scans via their website. You can check the results under the vulnerabilites tab of an image.
 
-_Note: [clair-in-ci](https://quay.io/repository/redhat-appstudio/clair-in-ci) is a feature which includes security scanning via clair. It is enabled by default for any Pipelines created in Konflux. A Tekton Task is available that can be used to run clair in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/tree/main/task/clair-scan/)._
+_Note: [clair-in-ci](https://quay.io/repository/redhat-appstudio/clair-in-ci) is a feature which includes security scanning via clair. It is enabled by default for any Pipelines created in Konflux. A Tekton Task is available that can be used to run clair in your own Pipelines [here](https://github.com/konflux-ci/build-definitions/tree/main/task/clair-scan/)._
 
 ### SAST Tools
 
@@ -44,7 +44,7 @@ _Note: [clair-in-ci](https://quay.io/repository/redhat-appstudio/clair-in-ci) is
 
 **synk** - https://github.com/snyk/cli
 
-_Note: Konflux uses synk to perform static analysis. A Tekton Task is available that can be used to run synk in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/blob/main/task/sast-snyk-check)._
+_Note: Konflux uses synk to perform static analysis. A Tekton Task is available that can be used to run synk in your own Pipelines [here](https://github.com/konflux-ci/build-definitions/blob/main/task/sast-snyk-check)._
 
 **checkov** - https://github.com/bridgecrewio/checkov
 - Checkov uses a common command line interface to manage and analyze infrastructure as code (IaC) scan results across platforms such as Terraform, CloudFormation, Kubernetes, Helm, ARM Templates and Serverless framework. ([source](https://www.checkov.io/))


### PR DESCRIPTION
STONEBLD-2339

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
