### PR TITLE
Further cleanup of the API docs

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -24,25 +24,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: crd-temp/application-api
-          repository: redhat-appstudio/application-api
-
-      - name: Checkout Build Service API
-        uses: actions/checkout@v3
-        with:
-          path: crd-temp/build-service
-          repository: redhat-appstudio/build-service
+          repository: konflux-ci/application-api
 
       - name: Checkout Integration Service API
         uses: actions/checkout@v3
         with:
           path: crd-temp/integration-service
-          repository: redhat-appstudio/integration-service
+          repository: konflux-ci/integration-service
 
       - name: Checkout Release Service API
         uses: actions/checkout@v3
         with:
           path: crd-temp/release-service
-          repository: redhat-appstudio/release-service
+          repository: konflux-ci/release-service
 
       - name: Checkout Enterprise Contract API
         uses: actions/checkout@v3
@@ -54,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: crd-temp/internal-services
-          repository: redhat-appstudio/internal-services
+          repository: konflux-ci/internal-services
 
       - name: Checkout Image Controller API
         uses: actions/checkout@v3
@@ -71,9 +65,6 @@ jobs:
 
       - name: Generate application and environment API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-environment-api.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
-
-      - name: Generate Build Service API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/build-service.md --renderer=markdown --source-path=crd-temp/build-service/api/v1alpha1/
 
       - name: Generate Image Controller API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/image-controller.md --renderer=markdown --source-path=crd-temp/image-controller/api/v1alpha1/

--- a/_config.yml
+++ b/_config.yml
@@ -12,16 +12,8 @@ navigation:
     sublist:
     - name: Application and Environment API
       link: /architecture/ref/application-environment-api.html
-    # - name: Service Provider (SPI)
-    #   link: /architecture/ref/service-provider.html
-    # - name: GitOps Service
-    #   link: /architecture/ref/gitops.html
-    - name: Build Service
-      link: /architecture/ref/build-service.html
     - name: Image Controller
       link: /architecture/ref/image-controller.html
-    # - name: JVM Build Service
-    #   link: /architecture/ref/jvm-build-service.html
     - name: Integration Service
       link: /architecture/ref/integration-service.html
     - name: Enterprise Contract


### PR DESCRIPTION
* Changing all repository locations to konflux-ci
* Removing the commented out sublist items
* Removal of the build service API as it was removed in June: https://github.com/konflux-ci/build-service/pull/305