### PR TITLE
feat(STONEINTG-948): migrate redhat-appstudio/clair-in-ci

### DIFF
--- a/tools/security-tools.MD
+++ b/tools/security-tools.MD
@@ -34,7 +34,7 @@ $ docker run --rm -i ghcr.io/hadolint/hadolint < Dockerfile
 - Check these [docs](https://quay.github.io/clair/howto/deployment.html) to understand the deployment models Clair currently uses.
 - For teams using quay.io as their container image registry, we enjoy the benefit of these scans via their website. You can check the results under the vulnerabilites tab of an image.
 
-_Note: [clair-in-ci](https://quay.io/repository/redhat-appstudio/clair-in-ci) is a feature which includes security scanning via clair. It is enabled by default for any Pipelines created in Konflux. A Tekton Task is available that can be used to run clair in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/tree/main/task/clair-scan/)._
+_Note: [clair-in-ci](https://quay.io/repository/konflux-ci/clair-in-ci) is a feature which includes security scanning via clair. It is enabled by default for any Pipelines created in Konflux. A Tekton Task is available that can be used to run clair in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/tree/main/task/clair-scan/)._
 
 ### SAST Tools
 


### PR DESCRIPTION
Update references to redhat-appstudio quay org to reflect move to konflux-ci.