### PR TITLE
fix(KONFLUX-5689): add Snapshot permissions for maintainers

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -45,10 +45,10 @@ We will use the built-in Kubernetes RBAC system for Konflux's role and permissio
 |               | Add User                |
 |               | User group (with SSO)   |
 | Maintainer    | Workspace               | Access to namespaces that backs workspace                                   |
-|               | Application             | appstudio.redhat.com      | get, list, watch, create, update, patch         | applications
+|               | Application             | appstudio.redhat.com      | get, list, watch, create, update, patch         | applications, snapshots
 |               | Component               | appstudio.redhat.com      | get, list, watch, create, update, patch         | components, componentdetectionqueries
 |               | ImageRepository         | appstudio.redhat.com      | get, list, watch, create, update, patch         | imagerepositories
-|               | Environment             | appstudio.redhat.com      | get, list, watch                                | promotionruns, snapshotenvironmentbindings, snapshots, environments
+|               | Environment             | appstudio.redhat.com      | get, list, watch                                | promotionruns, snapshotenvironmentbindings, environments
 |               | DeploymentTarget        | appstudio.redhat.com      | get, list, watch                                | deploymenttargets
 |               | DeploymentTargetClaim   | appstudio.redhat.com      | get, list, watch                                | deploymenttargetclaims
 |               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                                | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns


### PR DESCRIPTION
* Add create/update/patch permissions for the Snapshot resources to the Konflux maintainer role

Signed-off-by: dirgim <kpavic@redhat.com>