### PR TITLE
Adding service accounts permissions for admin role

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -94,7 +94,9 @@ We will use the built-in Kubernetes RBAC system for Konflux's role and permissio
 |               | Add User                |
 |               | User group (with SSO)   |
 |               | CronJob                 | batch                     | get, list, watch, create, update, patch, delete | cronjobs, jobs
-
+|               | RoleBinding             | rbac.authorization.k8s.io | get, list, create, update, patch, delete        | rolebindings, roles
+|               | ServiceAccount          |                           | get, list, create, update, patch, delete        | serviceaccounts
+|               | Token                   |                           | create                                          | serviceaccounts/token
 
 ## Consequences
 


### PR DESCRIPTION
Admin has access to manage service accounts and their specific permissions. Making sure that this is reflected in ADR.