### PR TITLE
Add CODEOWNERS for each subsystem design page

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @redhat-appstudio/book-publishers will be requested for
 # review when someone opens a pull request.
-*       @redhat-appstudio/book-publishers
+*       @konflux-ci/book-publishers
 
 /architecture/build-service.md              @konflux-ci/build-maintainers
 /architecture/enterprise-contract.md        @konflux-ci/ec

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,12 @@
 # @redhat-appstudio/book-publishers will be requested for
 # review when someone opens a pull request.
 *       @redhat-appstudio/book-publishers
+
+/architecture/build-service.md              @konflux-ci/build-maintainers
+/architecture/enterprise-contract.md        @konflux-ci/ec
+/architecture/hybrid-application-console.md @konflux-ci/konflux-ui
+/architecture/image-controller.md           @konflux-ci/build-maintainers
+/architecture/internal-services.md          @konflux-ci/release-service-maintainers
+/architecture/multi-platform-controller.md  @konflux-ci/infrastructure
+/architecture/release-service.md            @konflux-ci/release-service-maintainers
+/architecture/integration-service.md        @konflux-ci/integration-service-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @redhat-appstudio/book-publishers will be requested for
+# @konflux-ci/book-publishers will be requested for
 # review when someone opens a pull request.
 *       @konflux-ci/book-publishers
 


### PR DESCRIPTION
Let's do this similar to how we do the user docs repo.