### PR TITLE
Fix ADR 46 status

### DIFF
--- a/ADR/0046-common-task-runner-image.md
+++ b/ADR/0046-common-task-runner-image.md
@@ -4,7 +4,7 @@ Date: 2024-11-15
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
The ADR is accepted as seen in https://github.com/konflux-ci/architecture/pull/217. I just forgot to update the status before merging.