### PR TITLE
contributors and maintainer can read rolebindings

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -70,6 +70,7 @@ We will use the built-in Kubernetes RBAC system for Konflux's role and permissio
 |               | Add User                |
 |               | User group (with SSO)   |
 |               | CronJob                 | batch                     | get, list, watch                                | cronjobs, jobs
+|               | RoleBinding             | rbac.authorization.k8s.io | get, list                                       | rolebindings
 | Maintainer    | Workspace               | Access to namespaces that backs workspace                                   |
 |               | Application             | appstudio.redhat.com      | get, list, watch, create, update, patch         | applications, snapshots
 |               | Component               | appstudio.redhat.com      | get, list, watch, create, update, patch         | components, componentdetectionqueries
@@ -94,6 +95,7 @@ We will use the built-in Kubernetes RBAC system for Konflux's role and permissio
 |               | Add User                |
 |               | User group (with SSO)   |
 |               | CronJob                 | batch                     | get, list, watch, create, update, patch         | cronjobs, jobs
+|               | RoleBinding             | rbac.authorization.k8s.io | get, list                                       | rolebindings
 | Admin         | Workspace               | Access to namespaces that backs workspace                                   |
 |               | Application             | appstudio.redhat.com      | get, list, watch, create, update, patch, delete, deletecollection | applications
 |               | Component               | appstudio.redhat.com      | get, list, watch, create, update, patch, delete, deletecollection | components, componentdetectionqueries


### PR DESCRIPTION
With https://github.com/redhat-appstudio/infra-deployments/pull/6482 and https://github.com/redhat-appstudio/infra-deployments/pull/6373 we provided contributors and maintainer read access to RoleBindings

Signed-off-by: Francesco Ilario <filario@redhat.com>
