### PR TITLE
🚀 feat(jekyll): Add Mermaid diagram support for Jekyll site rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,23 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.0"
+gem "jekyll-mermaid", "~> 1.0.0"
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-mermaid"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby] 

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,21 @@ remote_theme: vaibhavvikas/jekyll-theme-minimalistic
 title: Architecture Of Konflux
 description: Technical documents about the Managed Developer Platform
 color-scheme: auto
+
+# Jekyll plugins
+plugins:
+  - jekyll-mermaid
+
+# Mermaid configuration
+mermaid:
+  # Mermaid version to use
+  version: "10.6.1"
+  # Theme (light, dark, or default)
+  theme: "default"
+  # Enable security features
+  securityLevel: "strict"
+  # Start counting from 1
+  startOnLoad: true
 navigation:
   - name: Technical Overview Document
     link: /architecture/architecture/index.html

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,2 @@
+<!-- Custom head includes for Mermaid support -->
+{% include mermaid.html %} 

--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -1,0 +1,46 @@
+<!-- Mermaid.js for rendering diagrams -->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.esm.min.mjs';
+  
+  // Configure Mermaid
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'default',
+    securityLevel: 'strict',
+    flowchart: {
+      useMaxWidth: true,
+      htmlLabels: true
+    },
+    themeVariables: {
+      darkMode: false,
+      primaryColor: '#4a148c',
+      primaryTextColor: '#000000',
+      primaryBorderColor: '#4a148c',
+      lineColor: '#424242',
+      secondaryColor: '#01579b',
+      tertiaryColor: '#e65100'
+    }
+  });
+  
+  // Initialize Mermaid
+  mermaid.init();
+</script>
+
+<!-- Fallback for older browsers -->
+<script>
+  // Check if ES modules are supported
+  if (!window.mermaid) {
+    // Load Mermaid from CDN as fallback
+    var script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js';
+    script.onload = function() {
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: 'default',
+        securityLevel: 'strict'
+      });
+      mermaid.init();
+    };
+    document.head.appendChild(script);
+  }
+</script> 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,8 @@
+---
+layout: base
+---
+
+<!-- Include Mermaid support -->
+{% include mermaid.html %}
+
+{{ content }} 

--- a/assets/css/mermaid.css
+++ b/assets/css/mermaid.css
@@ -1,0 +1,41 @@
+/* Mermaid diagram styling for Konflux Architecture site */
+
+.mermaid {
+  text-align: center;
+  margin: 20px 0;
+  padding: 20px;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  border: 1px solid #e9ecef;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .mermaid {
+    background-color: #2d3748;
+    border-color: #4a5568;
+  }
+}
+
+/* Ensure diagrams are responsive */
+.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Center diagram containers */
+.mermaid-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 20px 0;
+}
+
+/* Print-friendly styling */
+@media print {
+  .mermaid {
+    page-break-inside: avoid;
+    background-color: white !important;
+    border: 1px solid #ccc !important;
+  }
+} 


### PR DESCRIPTION
The basic problem here is that our new mermaid diagrams render nicely in github, but don't currently get rendered at all at (for example): https://konflux-ci.dev/architecture/ADR/0032-decoupling-deployment.html