### PR TITLE
update references to enterprise-contract-controller

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Checkout Enterprise Contract API
         uses: actions/checkout@v4
         with:
-          path: crd-temp/enterprise-contract-controller
-          repository: enterprise-contract/enterprise-contract-controller
+          path: crd-temp/crds
+          repository: conforma/crds
 
       - name: Checkout Internal Services API
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/release-service.md --renderer=markdown --source-path=crd-temp/release-service/api/v1alpha1/
 
       - name: Generate Enterprise Contract API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/enterprise-contract.md --renderer=markdown --source-path=crd-temp/enterprise-contract-controller/api/v1alpha1/
+        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/enterprise-contract.md --renderer=markdown --source-path=crd-temp/crds/api/v1alpha1/
 
       - name: Generate Internal Services API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/internal-services.md --renderer=markdown --source-path=crd-temp/internal-services/api/v1alpha1/

--- a/architecture/core/enterprise-contract.md
+++ b/architecture/core/enterprise-contract.md
@@ -77,7 +77,7 @@ includes the public key required to verify signatures, the list of policy
 and data sources, and any other required configuration.
 
 You can view the source code for the ECP CRD
-[here](https://github.com/enterprise-contract/enterprise-contract-controller) and
+[here](https://github.com/conforma/crds) and
 see its documentation [here](https://enterprise-contract.github.io/ecc/main/).
 See also the related
 [API Reference](https://redhat-appstudio.github.io/architecture/ref/enterprise-contract.html)


### PR DESCRIPTION
This commit updates references to the enterprise-contract-controller CRDs from
`github.com/enterprise-contract/enterprise-contract-controller` to `github.com/conforma/crds` as a result of sunsetting the `enterprise-contract` org.

Ref: EC-1422