### PR TITLE
ADR: Maven Build Pipelines

### DIFF
--- a/ADR/0058-maven-build-pipeline.md
+++ b/ADR/0058-maven-build-pipeline.md
@@ -10,12 +10,14 @@ Implementable
 
 Currently, Konflux lacks a native Java build experience, forcing developers to use Containerfiles
 for Java builds. The results are pushed as container images, which cannot be easily consumed by
-dependent Java projects.
+dependent Java projects. Konflux should provide validated build pipelines for Java projects to
+expand its relevance beyond the container/Cloud Native ecosystem.
 
-Apache [Maven](https://maven.apache.org/index.html) is the most widely adopted build tool for Java
-projects, although it is not hold an exclusive position. Java projects with Maven are distributed
-through [Maven Repositories](https://maven.apache.org/repositories/index.html), whose model has
-adopted by other Java build tools like [Gradle](https://gradle.org/).
+There are multiple build tools, frameworks, and even programming languages within the Java
+ecosystem. Apache [Maven](https://maven.apache.org/index.html) is the most widely adopted build
+tool for "standard" Java projects, although it is not the only one. Java projects built with Maven
+are often distributed through [Maven Repositories](https://maven.apache.org/repositories/index.html),
+whose model has been adopted by other Java build tools like [Gradle](https://gradle.org/).
 
 ### Goals for this feature
 
@@ -23,33 +25,53 @@ adopted by other Java build tools like [Gradle](https://gradle.org/).
 - Enable developers to specify custom Maven commands ("goals") during the build process, as well as
   input parameters/arguments.
 - Facilitate the publication of Java artifacts (JAR, WAR, POM) to a configured Maven repository for
-  use in a wider Konflux Application (or `ComponentGroup`).
-
+  use in a wider Konflux `Application` (or `ComponentGroup`).
 
 ### Key Requirements
 
 - Developers must be able to select a base builder image containing a desired OpenJDK and Maven
   version. Red Hat provides OpenJDK builders bundled with Maven 3.x through its UBI8 and UBI9
   catalogs.
-- The pipeline must invoke a reasonable default set of `mvn` commands (`mvn clean deploy`) to a
-  "dev" repository when code is merged. Code should not be deployed to a Maven repository for pull
-  request builds.
+- The pipeline must invoke a reasonable default set of `mvn` commands (`mvn clean deploy`) to build
+  and publish Maven content. The pipeline should support two modes of distribution:
+    - Package the Maven content as an OCI artifact, which can be pushed and pulled to a container
+      registry using compatible tools such as [ORAS](https://oras.land).
+    - Publish the content to one or more "dev" Maven repositories. One of these "dev" Maven
+      repositories must be treated as a source of truth for Renovate to "nudge" dependent Konflux
+      `Components`, and should not be polluted with pull request builds.
 - Developers must be able to provide arguments and CLI flags to the `mvn` command.
 - The build must produce OCI artifact references (`*_IMAGE_URL` and `*_IMAGE_DIGEST` or `IMAGES`)
   for Tekton Chains to generate provenance and signatures.
 - Support for [multi-module](https://maven.apache.org/guides/mini/guide-multiple-modules.html)
-  projects is required.
+  projects is required. The pipeline must be able to build and publish multiple Java artifacts
+  within a single build invocation using standard Maven commands/procedures. The pipeline does not
+  need to publish an OCI artifact for each built Java artifact.
 
 ### Non-Goals
 
-- Support for [Maven 4](https://maven.apache.org/whatsnewinmaven4.html).
-- Support for Gradle.
-- Support for Kotlin, Scala, or other JVM-based programming languages.
-- Provision Maven repositories for Java projects.
+- Support for [Maven 4](https://maven.apache.org/whatsnewinmaven4.html). At present, Maven 4 is
+  undergoing a lengthy "beta" testing cycle and has not released a generally available 4.0 vesion.
+  Maven 4 introduces several internal changes that will likely impact build and deploy processes.
+- Support for [Gradle](https://gradle.org/). This is a separate build tool that is not distributed
+  as part of Red Hat's UBI catalog. In the future, Konflux may need to obtain a build of Gradle
+  from a separate trusted source or rebuild it themselves.
+- Rebuild of the Maven build tool. For the interim, Konflux will consider the Red Hat UBI build of
+  Maven and OpenJDK as a "trusted source."
+- Support for [Scala](https://www.scala-lang.org/), [Kotlin](https://kotlinlang.org/), or other
+  JVM-based programming languages. These have separate build tooling and compilers, which Konflux
+  must obtain from a trusted source or likewise rebuild.
+- Provision Maven repositories for Java projects. This capability would need to be considered an
+  "add-on" and specific to a Maven repository provider (ex: Pulp, JFrog Artifactory, etc.).
+- Release artifacts to a Maven repository. Promoting Maven artifacts by copying/mirroring is not
+  well supported by the Maven command line tool. Release promotion processes are supported by some
+  artifact repository vendors (see examples for [JFrog Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/move-and-copy-artifacts)
+  and [AWS CodeArtifact](https://docs.aws.amazon.com/codeartifact/latest/ug/copy-package.html#copying-a-maven-package)).
 
 These can all be addressed through follow-up ADRs.
 
 ## Decision
+
+### Build Pipeline
 
 Konflux will provide one or more build pipelines for Maven which will execute up to two "deployments":
 
@@ -84,17 +106,19 @@ The core pipeline task, `maven-deploy-oras`, performs the following steps:
    image is non-runnable, with contents compressed with `gzip`. The output manifest is used for
    Tekton Chains signing.
 
-The pipeline will also include the following tasks:
+5. `generate-sbom`: this will generate the required component-level Software Bill of Materials from
+   multiple sources, aggregated with [Mobster](https://github.com/konflux-ci/mobster):
+   - The [CycloneDX Maven Plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin) if the Maven
+     project has configured its use.
+   - [Syft](https://github.com/anchore/syft)
+   - Hermeto once Maven is supported as a package manager (design is
+     [under discussion](https://github.com/hermetoproject/hermeto/pull/1046)).
 
-- `generate-sbom`: this will generate the required component-level Software Bill of Materials from
-  multiple sources, aggregated with [Mobster](https://github.com/konflux-ci/mobster):
-  - The [CycloneDX Maven Plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin) if the Maven
-    project has configured its use.
-  - [Syft](https://github.com/anchore/syft)
-  - Hermeto once Maven is supported as a package manager (design is
-    [under discussion](https://github.com/hermetoproject/hermeto/pull/1046)).
-- `build-source-container`: this will build a source container, using existing tasks in the Konflux
-  catalog.
+The pipeline will also build the source container, using existing tasks in the Konflux catalog.
+This artifact can be used to perform static code analysis against the source code used to compile
+the Java artifacts (see below).
+
+### Security Scanning
 
 Security scanning tasks will be omitted from the pipeline. These should be executed as part of an
 `IntegrationTestScenario` pipeline in accordance with [ADR-0048](./0048-movable-build-tests.md).
@@ -113,6 +137,87 @@ Scanning tasks should do the following:
 
    ```sh
    cd /konflux/scan-targets && snyk code test --sartif-file-output=snyk-results-code.sarif
+   ``` 
+
+Scanning tools may require access to the source code used to produce the Java artifacts in order to
+be effective, in which case the source artifact from the build pipeline should be used as input.
+
+### Consuming Maven Artifacts
+
+Java artifacts produced by the Maven build pipeline can be consumed by downstream ("nudged")
+components in one of two ways:
+
+#### Maven Repository Pattern
+
+In this pattern, downstream components reference dependencies as they would for any Maven artifact
+hosted outside of Maven Central. For Maven artifacts with `-SNAPSHOT` versions, downstream
+components should use a timestamped version number so that it can be updated by Renovate:
+
+```xml
+<!-- pom.xml -->
+  <repositories>
+    <repository>
+      <id>konflux-user-workloads</id>
+      <name>Konflux User Workloads Repository</name>
+      <url>https://{repository-host}/user-workloads</url>
+      <snapshots>
+        <enabled>true</enabled> <!-- Most teams will use SNAPSHOT versions during dev -->
+      <snapshots>
+      <releases>
+        <enabled>false</enabled> <!-- Can be enabled if SNAPSHOT versions are not used -->
+      <releases>
+  </repositories>
+  ...
+  <dependencies>
+    <dependency>
+      <groupId>group.id.for.component</groupId>
+      <artifactId>artifact-id</artifactId>
+      <version>1.0.0-20251216.185533-1<version> <!-- Timestamped build version, managed by Renovate -->
+    </dependency>
+    ...
+  <dependencies>
+
+```
+
+#### OCI Artifact
+
+In this pattern, the OCI artifact from the build is pulled and referenced in the consumer's build
+process. This may require multiple code changes; below is an example for a container build:
+
+1. Modify the consuming component's build configuration (ex: `pom.xml`) to reference a local
+   directory containing the extracted OCI artifact contents:
+
+   ```xml
+   <!-- pom.xml -->
+   <repositories>
+     <repository>
+       <id>konflux-component-{name}</id>
+       <name>Konflux Component {name} Extracted Repository</name>
+       <url>file:.konflux/maven/konflux-component-{name}</url>
+       <snapshots>
+         <enabled>true</enabled> <!-- Most teams will use SNAPSHOT versions during dev -->
+       </snapshots>
+       <releases>
+         <enabled>true</enabled> <!-- Can be enabled if SNAPSHOT versions are not used -->
+       </releases>
+     </repository>
+   </repositories>
+   ```
+
+2. Update the `Containerfile` to extract the OCI artifact
+
+   ```
+   FROM quay.io/konflux-ci/oras:latest@sha256:... AS maven-content
+   ARG MAVEN_IMAGE=quay.io/redhat-user-workloads/...
+   WORKDIR /konflux-build
+   RUN oras pull ${MAVEN_IMAGE} --output maven
+
+   FROM registry.redhat.io/ubi9/openjdk-17:latest
+   # For openjdk images, WORKDIR is set to a non-root "default" user home
+   COPY . /home/default/app-src
+   COPY --from=maven-content /konflux-build/maven /home/default/app-src/.konflux/maven/konflux-component-{name}
+   RUN mvn clean install
+   ...
    ```
 
 ## Consequences
@@ -145,7 +250,7 @@ Scanning tasks should do the following:
 - **Large Artifacts:** The output is a single OCI artifact containing an entire Maven repository,
   which can be very large (over 100 binary artifacts for some projects).
 - **SBOM Size:** The combined SBOM for multi-module projects can be enormous and potentially not
-  applicable to products at runtime.
+  applicable to individual Java artifacts at runtime.
 - **Scanning Limitations:** Due to the output not being a runnable container image, not all
   existing scanning tools (like Clair, Clamav, Coverity) are likely to support it. Scanning tools
   may not be capable of analyzing Java bytecode, and may need to scan the associated source code of
@@ -153,8 +258,10 @@ Scanning tasks should do the following:
 
 ### Rejected Alternatives
 
-**Push to Pulp**: Pulp has an OCI storage integration that allows uploaded artifacts to have an
-associated OCI artifact digest. This alternative was rejected for several reasons:
+**Push to Pulp**: [Pulp](https://pulpproject.org/pulp_maven/) has a plugin for Maven, as well as an
+[OCI storage integration](https://pulpproject.org/pulp_container/docs/admin/guides/change-allowed-artifacts/?h=oci).
+This integration allows uploaded artifacts to have an associated OCI artifact digest. This
+alternative was rejected for several reasons:
 
 - Although Pulp has some support for [Maven repositories](https://pulpproject.org/pulp_maven/docs/user/guides/deploy/),
   its plugin is missing critical features needed to be used in a production environment.


### PR DESCRIPTION
This ADR proposes a means for Konflux to support Java builds with Maven.

Assisted-by: Gemini