### PR TITLE
Use map-based schema for trusted_task_rules

### DIFF
--- a/ADR/0053-trusted-task-model.md
+++ b/ADR/0053-trusted-task-model.md
@@ -115,6 +115,11 @@ Note:
 This ADR doesn't mandate a specific format for `trusted_task_rules`, but does
 come with an example of what it could look like - see the [Appendix](#appendix).
 
+Note: The `trusted_task_rules` structure uses maps (keyed by a descriptive name)
+rather than arrays for the `allow` and `deny` fields. This is because OPA does
+not merge arrays — when multiple data sources contribute rules, array values
+would conflict instead of combining. Map-based keys merge naturally in OPA.
+
 ### Trust upstream Konflux Tasks based on bundle URL
 
 A policy author who wants to trust all the upstream Konflux Tasks should do so by
@@ -215,39 +220,31 @@ This is an attempt to illustrate how such a mechanism could look.
 ```yaml
 trusted_task_rules:
   allow:
-    - name: Implicitly trust all tasks from konflux-ci/tekton-catalog
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/*
-
-    - name: Require common signing key  # starting in 2026
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/*
-      signing_key: <common public key for konflux-ci Tasks>
-      effective_on: 2026-01-01
+    tekton-catalog-tasks:
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/*
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/*
+        signing_key: <common public key for konflux-ci Tasks>
+        effective_on: 2026-01-01
   deny:
-    - name: Deprecate the old reference for task-build-image-index
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest
-      message: >
-        The task was renamed to 'build-image-index',
-        please replace the task reference with an equivalent one from
-        https://quay.io/konflux-ci/tekton-catalog/task-build-image-index
-      effective_on: 2025-10-26
-
-    - name: Expire all buildah task versions below 0.5
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/task-buildah*
-      versions:
-        - '<0.5'
-      effective_on: 2025-11-15
-
-    - name: Expire all buildah task versions below 0.5.1
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/task-buildah*
-      versions:
-        - '<0.5.1'
-      effective_on: 2025-11-29  # (later than 0.5)
-
-    - name: Expire the older 2.x versions of task-foo without affecting 1.x
-      pattern: oci://quay.io/konflux-ci/tekton-catalog/task-foo
-      versions:
-        - '>=2,<2.1.0'
-      effective_on: 2025-10-30
+    tekton-catalog-tasks:
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-build-image-manifest
+        message: >
+          The task was renamed to 'build-image-index',
+          please replace the task reference with an equivalent one from
+          https://quay.io/konflux-ci/tekton-catalog/task-build-image-index
+        effective_on: 2025-10-26
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-buildah*
+        versions:
+          - '<0.5'
+        effective_on: 2025-11-15
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-buildah*
+        versions:
+          - '<0.5.1'
+        effective_on: 2025-11-29  # (later than 0.5)
+      - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-foo
+        versions:
+          - '>=2,<2.1.0'
+        effective_on: 2025-10-30
 ```
 
 `is_allowed_by_trusted_task_rules(task_reference)`:

--- a/ADR/0053-trusted-task-model.md
+++ b/ADR/0053-trusted-task-model.md
@@ -202,39 +202,6 @@ Note that Conforma also supports [setting Task expiry] manually via the
 
 ## Appendix
 
-### Why maps instead of arrays
-
-The `trusted_task_rules` structure uses maps (keyed by a descriptive name)
-rather than arrays for the `allow` and `deny` fields. This is driven by how
-OPA merges data from multiple sources.
-
-When OPA loads data from multiple sources (e.g. separate bundles or data
-files), it merges them into a single `data` document. The merge is recursive
-for maps — keys from both sides are combined into one map. But if two sources
-define the same key path with a non-map value (an array, a scalar, or null),
-OPA treats it as a conflict and **fails the entire data load**.
-
-For example, suppose two bundles each contribute rules under
-`trusted_task_rules.allow`:
-
-```yaml
-# Bundle A                          # Bundle B
-trusted_task_rules:                  trusted_task_rules:
-  allow:                               allow:
-    tekton-catalog-tasks:                my-org-tasks:
-      - pattern: oci://quay.io/…          - pattern: oci://my.registry/…
-```
-
-Because `allow` is a map, OPA merges the two: the result has both
-`tekton-catalog-tasks` and `my-org-tasks` as keys under `allow`. If `allow`
-were an array instead, both bundles would define the same key path
-(`trusted_task_rules.allow`) with an array value, and OPA would reject the
-data at load time.
-
-The map keys themselves (`tekton-catalog-tasks`, `my-org-tasks`) are
-descriptive labels. Conforma treats them as opaque — it iterates over all
-values in the map to collect the full set of rules, regardless of key names.
-
 ### Example `trusted_task_rules` mechanism
 
 The `trusted_task_rules` mechanism should:
@@ -284,6 +251,39 @@ matching `allow` rules with an `effective_on` date not in the future.
 
 The task reference meets the criteria in any matching `deny` rule with an `effective_on`
 date not in the future.
+
+### Why maps instead of arrays
+
+The `trusted_task_rules` structure uses maps (keyed by a descriptive name)
+rather than arrays for the `allow` and `deny` fields. This is driven by how
+OPA merges data from multiple sources.
+
+When OPA loads data from multiple sources (e.g. separate bundles or data
+files), it merges them into a single `data` document. The merge is recursive
+for maps — keys from both sides are combined into one map. But if two sources
+define the same key path with a non-map value (an array, a scalar, or null),
+OPA treats it as a conflict and **fails the entire data load**.
+
+For example, suppose two bundles each contribute rules under
+`trusted_task_rules.allow`:
+
+```yaml
+# Bundle A                          # Bundle B
+trusted_task_rules:                  trusted_task_rules:
+  allow:                               allow:
+    tekton-catalog-tasks:                my-org-tasks:
+      - pattern: oci://quay.io/…          - pattern: oci://my.registry/…
+```
+
+Because `allow` is a map, OPA merges the two: the result has both
+`tekton-catalog-tasks` and `my-org-tasks` as keys under `allow`. If `allow`
+were an array instead, both bundles would define the same key path
+(`trusted_task_rules.allow`) with an array value, and OPA would reject the
+data at load time.
+
+The map keys themselves (`tekton-catalog-tasks`, `my-org-tasks`) are
+descriptive labels. Conforma treats them as opaque — it iterates over all
+values in the map to collect the full set of rules, regardless of key names.
 
 [Trusted Tasks]: https://conforma.dev/docs/policy/trusted_tasks.html
 [data-acceptable-bundles]: https://quay.io/repository/konflux-ci/tekton-catalog/data-acceptable-bundles

--- a/ADR/0053-trusted-task-model.md
+++ b/ADR/0053-trusted-task-model.md
@@ -115,11 +115,6 @@ Note:
 This ADR doesn't mandate a specific format for `trusted_task_rules`, but does
 come with an example of what it could look like - see the [Appendix](#appendix).
 
-Note: The `trusted_task_rules` structure uses maps (keyed by a descriptive name)
-rather than arrays for the `allow` and `deny` fields. This is because OPA does
-not merge arrays — when multiple data sources contribute rules, array values
-would conflict instead of combining. Map-based keys merge naturally in OPA.
-
 ### Trust upstream Konflux Tasks based on bundle URL
 
 A policy author who wants to trust all the upstream Konflux Tasks should do so by
@@ -206,6 +201,39 @@ Note that Conforma also supports [setting Task expiry] manually via the
 `build.appstudio.redhat.com/expires-on` annotation. This will still work.
 
 ## Appendix
+
+### Why maps instead of arrays
+
+The `trusted_task_rules` structure uses maps (keyed by a descriptive name)
+rather than arrays for the `allow` and `deny` fields. This is driven by how
+OPA merges data from multiple sources.
+
+When OPA loads data from multiple sources (e.g. separate bundles or data
+files), it merges them into a single `data` document. The merge is recursive
+for maps — keys from both sides are combined into one map. But if two sources
+define the same key path with a non-map value (an array, a scalar, or null),
+OPA treats it as a conflict and **fails the entire data load**.
+
+For example, suppose two bundles each contribute rules under
+`trusted_task_rules.allow`:
+
+```yaml
+# Bundle A                          # Bundle B
+trusted_task_rules:                  trusted_task_rules:
+  allow:                               allow:
+    tekton-catalog-tasks:                my-org-tasks:
+      - pattern: oci://quay.io/…          - pattern: oci://my.registry/…
+```
+
+Because `allow` is a map, OPA merges the two: the result has both
+`tekton-catalog-tasks` and `my-org-tasks` as keys under `allow`. If `allow`
+were an array instead, both bundles would define the same key path
+(`trusted_task_rules.allow`) with an array value, and OPA would reject the
+data at load time.
+
+The map keys themselves (`tekton-catalog-tasks`, `my-org-tasks`) are
+descriptive labels. Conforma treats them as opaque — it iterates over all
+values in the map to collect the full set of rules, regardless of key names.
 
 ### Example `trusted_task_rules` mechanism
 


### PR DESCRIPTION
OPA doesn't merge arrays, so adding a top-level key.