### PR TITLE
Rename & update ADR file for ecosystem native distribution

### DIFF
--- a/ADR/0066-ecosystem-native-distribution.md
+++ b/ADR/0066-ecosystem-native-distribution.md
@@ -16,7 +16,7 @@ Date: 2026-03-18
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/ADR/0066-ecosystem-native-distribution.md
+++ b/ADR/0066-ecosystem-native-distribution.md
@@ -1,8 +1,7 @@
 ---
-title: "XXXX. Ecosystem-Native Distribution for Non-OCI Artifacts"
-status: Proposed
-applies_to:
-  - release-service
+title: "66. Ecosystem-Native Distribution for Non-OCI Artifacts"
+status: Accepted
+applies_to: []
 topics:
   - release
   - rpm


### PR DESCRIPTION
Give the new ADR an ID, set the correct state and remove applies_to as the ADR does not apply to release service.