### PR TITLE
fix: Extract shared list-adr-files to deduplicate ADR exclusions

### DIFF
--- a/hack/generate-adr-index
+++ b/hack/generate-adr-index
@@ -28,12 +28,8 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 EOF
 
 # Process all ADR files in order
-for adr_file in "${ADR_DIR}"/*.md; do
-  # Skip the index file itself and the template
+while IFS= read -r adr_file; do
   filename=$(basename "${adr_file}")
-  if [[ "${filename}" == "index.md" ]] || [[ "${filename}" == "0000-adr-template.md" ]]; then
-    continue
-  fi
 
   # Extract the ADR number from the filename
   if [[ "${filename}" =~ ^([0-9]{4})- ]]; then
@@ -57,6 +53,6 @@ for adr_file in "${ADR_DIR}"/*.md; do
   else
     echo "- [${title}](./${link_name}/)" >> "${INDEX_FILE}"
   fi
-done
+done < <("${SCRIPT_DIR}/util/list-adr-files")
 
 echo "✅ Generated ${INDEX_FILE}"

--- a/hack/lint-adr-numbers
+++ b/hack/lint-adr-numbers
@@ -39,11 +39,13 @@ warning() {
     echo -e "${YELLOW}WARNING:${NC} $1"
 }
 
-# Find all ADR markdown files (excluding index.md and template)
+# Find all ADR markdown files (excluding non-ADR markdown)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UTIL_LIST="${SCRIPT_DIR}/util/list-adr-files"
 adr_files=()
-while IFS= read -r -d '' file; do
+while IFS= read -r file; do
     adr_files+=("$file")
-done < <(find ADR/ -name "*.md" -type f ! -name "index.md" ! -name "0000-adr-template.md" ! -name "AGENTS.md" -print0 | sort -z)
+done < <("$UTIL_LIST")
 
 if [[ ${#adr_files[@]} -eq 0 ]]; then
     warning "No ADR markdown files found in ADR/ directory"

--- a/hack/lint-adr-status
+++ b/hack/lint-adr-status
@@ -54,11 +54,12 @@ if [[ ! -x "$UTIL_DIR/get-adr-status.sh" ]]; then
     exit 1
 fi
 
-# Find all ADR markdown files (excluding index.md and template)
+# Find all ADR markdown files (excluding non-ADR markdown)
+UTIL_LIST="${SCRIPT_DIR}/util/list-adr-files"
 adr_files=()
-while IFS= read -r -d '' file; do
+while IFS= read -r file; do
     adr_files+=("$file")
-done < <(find ADR/ -name "*.md" -type f ! -name "index.md" ! -name "0000-adr-template.md" ! -name "AGENTS.md" -print0 | sort -z)
+done < <("$UTIL_LIST")
 
 if [[ ${#adr_files[@]} -eq 0 ]]; then
     warning "No ADR markdown files found in ADR/ directory"

--- a/hack/util/generate-adr-table
+++ b/hack/util/generate-adr-table
@@ -32,13 +32,11 @@ EOF
 
 echo "| ADR | Status | Created | Updated |"
 echo "| --- | --- | --- | --- |"
-for adr in ADR/*.md; do
-	[[ "$adr" == "ADR/index.md" ]] && continue
-	[[ "$adr" == "ADR/0000-adr-template.md" ]] && continue
+while IFS= read -r adr; do
 	title=$(grep -m1 "^# " "${adr}");
 	status=$(hack/util/get-adr-status "${adr}")
 	emoji=$(get_status_emoji "$status")
 	created=$(git log --follow --format=%ad --date short "${adr}" | tail -1)
 	updated=$(git log --follow --format=%ad --date short "${adr}" | head -1)
 	echo "|[${title:2}](./${adr#ADR/})|$emoji $status|$created|$updated|"
-done
+done < <("$(dirname "$0")/list-adr-files")

--- a/hack/util/list-adr-files
+++ b/hack/util/list-adr-files
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Output one ADR file path per line, sorted, excluding non-ADR markdown.
+find ADR/ -name "*.md" -type f \
+  ! -name "index.md" \
+  ! -name "0000-adr-template.md" \
+  ! -name "AGENTS.md" \
+  | sort


### PR DESCRIPTION
## Summary

- The ADR index page on konflux-ci.dev/architecture/ADR/ shows a titleless entry because `AGENTS.md` wasn't excluded from the table generator
- The same exclusion list (`index.md`, `0000-adr-template.md`, `AGENTS.md`) was duplicated across four scripts, and two of them were already missing `AGENTS.md`
- Extracts a shared `hack/util/list-adr-files` script that all consumers now call, so future non-ADR markdown files only need one update

## Test plan

- [ ] `./hack/util/list-adr-files` outputs only numbered ADR files (no `index.md`, template, or `AGENTS.md`)
- [ ] `./hack/util/generate-adr-table | tail -5` ends at ADR 66 with no blank row
- [ ] `make lint-adr-status` passes
- [ ] `make lint-adr-numbers` passes (requires bash 4+ — pre-existing issue on macOS)
- [ ] Rendered site at konflux-ci.dev/architecture/ADR/ no longer shows titleless entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)