### PR TITLE
remove obsolete SnapshotEnvironmentBinding deployment path

### DIFF
--- a/architecture/AGENTS.md
+++ b/architecture/AGENTS.md
@@ -7,7 +7,7 @@ core/index.md 175L — Core Services
 core/integration-service.md 225L — Test orchestration, snapshot creation/validation, promotion logic
 core/konflux-ui.md 20L — Web UI for Konflux platform (minimal architecture docs in this repo)
 core/pipeline-service.md 134L — Foundational Tekton APIs, Pipelines as Code, Chains (signing), Results (archival)
-core/release-service.md 147L — Release orchestration, privileged pipelines, cross-namespace releases
+core/release-service.md 136L — Release orchestration, privileged pipelines, cross-namespace releases
 add-ons/image-controller.md 216L — Image repository setup, robot account management, secret linking to ServiceAccounts
 add-ons/index.md 239L — Add-ons
 add-ons/internal-services.md 141L — Remote cluster polling for executing internal jobs across network boundaries

--- a/architecture/core/release-service.md
+++ b/architecture/core/release-service.md
@@ -71,7 +71,6 @@ Below is the list of CRs that the Release service is responsible for interacting
 
 | Custom Resource             | When?                                                       | Why?                                                                                          |
 |-----------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| SnapshotEnvironmentBinding  | When deploying the Snapshot to an Environment               | To create a SnapshotEnvironmentBinding for the referenced Environment when one does not exist |
 | PipelineRun                 | Once a Release has been composed and is ready for execution | To perform the steps in the Release Pipeline                                                  |
 
 ### READ
@@ -87,7 +86,6 @@ Below is the list of CRs that the Release service is responsible for interacting
 
 | Custom Resource            | When?                                                    | Why?                                                             |
 |----------------------------|----------------------------------------------------------|------------------------------------------------------------------|
-| SnapshotEnvironmentBinding | When deploying the Snapshot to an Environment            | To update existing SnapshotEnvironmentBinding for a new Snapshot |
 | Release                    | During the lifecycle of an attempt to release a Snapshot | To provide status for the execution of the Release Pipeline      |
 
 ### WATCH
@@ -96,7 +94,6 @@ Below is the list of CRs that the Release service is responsible for interacting
 |----------------------------|------------------------------------------------------------|--------------------------------------------------------------------|
 | Release                    | Always                                                     | To provide an API to trigger a release                             |
 | PipelineRun                | Once the PipelineRun is created                            | To relay the Release PipelineRun status to the Release for viewing |
-| SnapshotEnvironmentBinding | After the SnapshotEnvironmentBinding is created or updated | To relay the GitOps deployment status to the Release for viewing   |
 
 #### Annotations/Labels
 
@@ -118,11 +115,6 @@ The Release service will copy the annotations and labels from the Release CR and
 3. Extract the `spec.pipelineRef`, `spec.serviceAccount`, `spec.policy` from the ReleasePlanAdmission
 5. Create a Release PipelineRun using the above info.
 6. Watch Release PipelineRun and update Release `status` with progress and outcome.
-7. If ReleasePlanAdmission specified a `spec.environment`, then do the following:
-   * Copy the Snapshot to the managed workspace.
-   * Verify that the Application and Components have been copied to managed workspace.
-   * Create or update SnapshotEnvironmentBinding in the managed workspace.
-   * Watch SnapshotEnvironmentBinding to relay deployment status to Release CR `status`.
 
 ### Dependencies
 
@@ -132,10 +124,7 @@ The [Release Service](./release-service.md) is dependent on the following servic
 - [Integration Service](./integration-service.md)
     - Facilitates automated testing of content produced by the build pipelines
 - [GitOps Service](./gitops-service.md)
-    - Provides the facility to create
-        - Snapshots defining sets of Builds to release
-        - Environment to deploy the Application to
-        - SnapshotEnvironmentBindings to have the Snapshot of the Application deployed to a specific Environment
+    - Provides the facility to create Snapshots defining sets of Builds to release
 - [Enterprise Contract Service](./enterprise-contract.md)
     - Provides facilities to validate whether content has passed the Enterprise Contract.
 


### PR DESCRIPTION
The release-service doc described a SnapshotEnvironmentBinding (SEB) deployment path in workflow step 7 and referenced SEBs in the CREATE, UPDATE, and WATCH CRUD tables. This code path was removed from the release-service implementation as part of ADR-0032 (decoupling deployment from release), but the documentation was never updated to reflect the change.
