### PR TITLE
doc(KONFLUX-13118): Add architecture documentation for the Konflux Operator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Each subdirectory has an `AGENTS.md` with document maps and line counts for cont
 - Service docs: `architecture/core/*.md` and `architecture/add-ons/*.md` — see `architecture/AGENTS.md`
 - ADRs: `ADR/NNNN-*.md` — see `ADR/AGENTS.md`
 - ADR template: `ADR/0000-adr-template.md` (31 lines)
-- System overview: `architecture/index.md` (424 lines — read only when 3+ services involved)
+- System overview: `architecture/index.md` (426 lines — read only when 3+ services involved)
 
 Use frontmatter to filter: `overview:` in service docs, `status:`/`applies_to:`/`topics:` in ADRs.
 

--- a/architecture/AGENTS.md
+++ b/architecture/AGENTS.md
@@ -1,10 +1,11 @@
-index.md 424L — Full system overview (read when 3+ services involved)
+index.md 426L — Full system overview (read when 3+ services involved)
 
 core/build-service.md 285L — Build pipelines, Tekton PipelineRun definitions, Component builds
 core/enterprise-contract.md 198L — Policy enforcement, attestation validation, release gating
 core/hybrid-application-service.md 371L — Validation webhooks for Application and Component CRs
-core/index.md 175L — Core Services
+core/index.md 180L — Core Services
 core/integration-service.md 225L — Test orchestration, snapshot creation/validation, promotion logic
+core/konflux-operator.md 41L — Platform installation and lifecycle management via Konflux CR
 core/konflux-ui.md 20L — Web UI for Konflux platform (minimal architecture docs in this repo)
 core/pipeline-service.md 134L — Foundational Tekton APIs, Pipelines as Code, Chains (signing), Results (archival)
 core/release-service.md 147L — Release orchestration, privileged pipelines, cross-namespace releases

--- a/architecture/core/index.md
+++ b/architecture/core/index.md
@@ -166,6 +166,10 @@ The [Enterprise Contract] ensures container images produced by Konflux meet clea
 
 The [Konflux UI] provides a web-based user interface for interacting with Konflux. It offers a unified interface for managing Applications, Components, and monitoring builds, tests, and releases across the entire development lifecycle.
 
+### Konflux Operator
+
+The [Konflux Operator] is a Kubernetes operator that installs, configures, and manages the entire Konflux platform from a single `Konflux` Custom Resource. It deploys all core services and selected optional components listed on this page, handles configuration propagation, and provides declarative lifecycle management for the platform.
+
 [Hybrid Application Service]: ./hybrid-application-service.md
 [Build Service]: ./build-service.md
 [Integration Service]: ./integration-service.md
@@ -173,3 +177,4 @@ The [Konflux UI] provides a web-based user interface for interacting with Konflu
 [Pipeline Service]: ./pipeline-service.md
 [Enterprise Contract]: ./enterprise-contract.md
 [Konflux UI]: ./konflux-ui.md
+[Konflux Operator]: ./konflux-operator.md

--- a/architecture/core/konflux-operator.md
+++ b/architecture/core/konflux-operator.md
@@ -1,0 +1,41 @@
+---
+title: Konflux Operator
+eleventyNavigation:
+  key: Konflux Operator
+  parent: Core Services
+  order: 1
+toc: true
+overview:
+  scope: "Platform installation and lifecycle management via Konflux CR"
+  key_crds:
+    - Konflux
+  related_services:
+    - build-service
+    - integration-service
+    - release-service
+    - pipeline-service
+    - enterprise-contract
+    - konflux-ui
+  related_adrs: []
+  key_concepts:
+    - Single Konflux CR reconciles all platform components
+    - Declarative lifecycle management (install, upgrade, configure, remove)
+    - Optional component toggling (image controller, internal registry, telemetry)
+---
+
+# Konflux Operator
+
+The Konflux Operator is a Kubernetes operator that installs, configures, and manages the entire Konflux platform from a single declarative `Konflux` Custom Resource. It deploys all core services and selected optional components, propagates configuration changes, and removes disabled components automatically.
+
+The operator reconciles the top-level `Konflux` CR into a set of child CRs, one per platform component, each managed by its own sub-reconciler. This fan-out pattern keeps component logic isolated while providing a single control point for platform administrators.
+
+## Key CRDs
+
+| CRD | API Group | Description |
+|-----|-----------|-------------|
+| `Konflux` | `konflux.konflux-ci.dev/v1alpha1` | Defines the desired state of the entire Konflux platform installation |
+
+## Further Reading
+
+- **Documentation** (installation, configuration, API reference): <https://konflux-ci.dev/konflux-ci/docs/>
+- **Source code**: <https://github.com/konflux-ci/konflux-ci> (see `operator/` directory)

--- a/architecture/index.md
+++ b/architecture/index.md
@@ -310,6 +310,8 @@ These services make up the core of Konflux and are all required for a working sy
   chain capabilities to other services
 - [Enterprise Contract](./core/enterprise-contract.md) - A specialized sub-service responsible for the
   definition and enforcement of policies related to how OCI artifacts are built and tested.
+- [Konflux Operator](./core/konflux-operator.md) - A Kubernetes operator that installs and manages
+  the entire Konflux platform from a single `Konflux` Custom Resource.
 
 ### Konflux Add-Ons
 


### PR DESCRIPTION
Add the Konflux Operator as a core service in the architecture docs.
Rather than duplicating the comprehensive documentation already
available at https://konflux-ci.dev/konflux-ci/docs/, this adds a
concise architectural reference describing the operator's role and
links to the external docs and source code.

Changes:
- New architecture/core/konflux-operator.md
- Updated architecture/core/index.md with operator subsection
- Updated architecture/index.md core services list
- Updated CLAUDE.md line count reference
- Regenerated AGENTS.md

Closes https://github.com/konflux-ci/architecture/issues/331

Assisted-by: Cursor + Opus 4.6