### PR TITLE
Add ADR (0073): Konflux README status badges

### DIFF
--- a/ADR/0073-readme-status-badges.md
+++ b/ADR/0073-readme-status-badges.md
@@ -28,26 +28,15 @@ Today, users must open the Konflux UI (SSO) or the GitHub Checks popup to see st
 
 Beyond README badges, the same service can power **monitoring dashboards**, **portfolio status pages**, and **third-party integrations** (Slack bots, Jira, Confluence) via a JSON endpoint.
 
-### Spike findings
-
-We evaluated options and measured real repositories (`konflux-ci/konflux-ci`, `konflux-ci/segment-bridge`).
-
-| Approach | Tested | Verdict | Why |
-|---|---|---|---|
-| Shields.io `github/check-runs` | Live URLs + [source](https://github.com/badges/shields/blob/master/services/github/github-check-runs.service.js) | **Rejected** | Reads only first ~30 check-run rows. Busy repos have 50–70+; Konflux `*-on-push` often at row 31+ → `no check runs`. Third-party SaaS; weak for private repos. |
-| GitHub Action → commit `badge/*.svg` | Prototype workflow | **Rejected** | Mixes CI status into source; per-repo maintenance; org-wide pattern needs ADR anyway. |
-| Tekton task → git push SVG | Design review | **Rejected** | Same concerns as git-commit approach. |
-| Self-hosted Shields (`check-runs`) | Code review | **Rejected** | Same 30-row limit unless forked. Self-host helps RH control, not pagination. |
-| **Spike CLI: paginated Checks → SVG** | `go run` against segment-bridge | **Works** | Proves data + render logic; basis for service design. |
-
 ### Constraints
 
-- README is rendered by GitHub — badge URL must be **reachable without user SSO** (public HTTPS or designed private-repo auth).
+- README is rendered by GitHub — badge URL must be **reachable over public HTTPS**.
 - Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional but have established precedent (Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md), PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), registration-service). The [architecture overview](../architecture/index.md) permits these exceptions when justified.
 - Check runs are the status entries visible on each commit's **Checks tab** — the `-on-push` pipelines and `enterprise-contract` checks that PaC reports back to GitHub.
 - Check names are **per-component** (`*-on-push`, `*enterprise-contract*`), not one org-wide GitHub check name.
 - **Ring / release** status is not fully on GitHub Checks — requires cluster data (Tekton Results, Release CRs) later.
 - Konflux runs on **multiple production clusters**, and tenants from the same GitHub organization may be spread across different clusters.
+- Konflux onboarding data (Component CRs, tenant config) records **git URLs** but not GitHub repository visibility (public vs private). The proportion of private onboarded repos is unknown without querying the GitHub API per repository.
 
 ## Decision
 
@@ -58,6 +47,32 @@ Introduce a **Konflux Badge Service** — a new **read-only HTTP service** (host
 3. Uses the **paginated GitHub Checks API** initially for **build** and **EC** status on a branch HEAD.
 4. Extends later to **Tekton Results / Konflux CRs** for Ring and richer status, within the same codebase.
 5. Uses a **server-side GitHub credential** (GitHub App installation token stored in a Kubernetes Secret).
+
+### Data flow
+
+GitHub README images are fetched by GitHub's [camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — a plain HTTPS GET with **no viewer login** passed to the badge service. The badge service calls the GitHub API using the **PaC GitHub App** installation token (same App/credentials PaC uses to report check runs; stored in a cluster Secret).
+
+```mermaid
+sequenceDiagram
+    participant Viewer
+    participant GH as GitHub (README + camo)
+    participant Badge as Badge Service
+    participant GHAPI as GitHub API
+
+    Viewer->>GH: Open README
+    GH->>Badge: GET /badge/{org}/{repo}/{branch}/build
+    Badge->>GHAPI: GET /repos/{org}/{repo} (App token)
+    GHAPI-->>Badge: private: true/false
+    alt public repo
+        Badge->>GHAPI: GET check-runs
+        Badge-->>GH: SVG (pass/fail/running)
+    else private repo
+        Badge-->>GH: SVG (neutral — no status)
+    end
+    GH-->>Viewer: Render badge
+```
+
+**Public vs private (one URL, different response):** the service reads `repo.private` from the GitHub API. **Public** → fetch check runs, return real status SVG/JSON. **Private** → unauthenticated SVG returns a neutral badge only (no pass/fail); real status stays on GitHub Checks (for users with repo access). Returning real status for private repos on an open URL would let anyone who knows `org/repo/branch` learn build health without repo access.
 
 ### API shape
 
@@ -149,15 +164,14 @@ This decision is deferred because it depends on which cluster data sources are n
 
 ## Alternatives Considered
 
-| Alternative | Verdict | Rationale |
-|---|---|---|
-| Shields.io SaaS only | **Rejected** | Low effort but fails at scale (pagination, third party, private repos). |
-| Per-repo GitHub Action publisher | **Rejected** | Technically viable; CI status in git plus N workflows to maintain is not org-scalable. |
-| Konflux UI deep-link only | **Insufficient** | Meets "see status" but not embeddable badge — does not satisfy stated product goal. |
-| Self-hosted Shields (`check-runs`) | **Rejected** | Does not fix pagination without a fork. Acceptable only as renderer (`endpoint?url=<our JSON>`); direct SVG is simpler. |
-| Deploy per-cluster from the start | **Deferred** | Unnecessary for GitHub-only data path. Adds deployment complexity without benefit until the service reads cluster-internal data. |
-| Extend Tekton Results with a badge endpoint | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge logic there is out of scope. It also uses Bearer token auth, incompatible with GitHub's anonymous image fetching. |
-| JSON-only service + self-hosted Shields for SVG | **Rejected** | Requires deploying two services. Since `badge-maker` handles SVG rendering trivially, a single service serving both JSON and SVG is simpler to operate. |
+| Alternative | Evaluated | Verdict | Rationale |
+|---|---|---|---|
+| Shields.io SaaS `github/check-runs` | Live URLs on `konflux-ci/konflux-ci`, `konflux-ci/segment-bridge`; [source review](https://github.com/badges/shields/blob/master/services/github/github-check-runs.service.js) | **Rejected** | Reads only first ~30 check-run rows. Busy repos have 50–70+; Konflux `*-on-push` often at row 31+ → `no check runs`. Third-party SaaS; weak for private repos. |
+| GitHub Action → commit `badge/*.svg` to repo | Prototype workflow | **Rejected** | Mixes CI status into source; per-repo maintenance; |
+| Tekton task → git push SVG | Design review | **Rejected** | Same concerns as git-commit approach. |
+| Deploy per-cluster from the start | Design review | **Deferred** | Unnecessary for GitHub-only data path. Adds deployment complexity without benefit until the service reads cluster-internal data. |
+| Extend Tekton Results with a badge endpoint | Design review | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge logic there is out of scope. Bearer token auth incompatible with GitHub's anonymous image fetching. Badge service reads GitHub Checks (reported by PaC), not raw PipelineRun results. |
+| JSON-only service + self-hosted Shields for SVG | Design review | **Rejected** | Requires deploying two services. `badge-maker` renders SVG trivially; single service serving both JSON and SVG is simpler to operate. |
 
 ## Consequences
 

--- a/ADR/0073-readme-status-badges.md
+++ b/ADR/0073-readme-status-badges.md
@@ -1,0 +1,193 @@
+---
+title: "73. README Status Badges via Konflux Badge Service"
+status: Proposed
+applies_to:
+  - pipeline-service
+topics:
+  - github-integration
+  - badges
+  - external-api
+  - observability
+---
+
+# 73. README Status Badges via Konflux Badge Service
+
+Date: 2026-08-13
+
+## Status
+
+Proposed
+
+## Context
+
+### Problem
+
+Teams want **embeddable build status** on the default branch README (Jenkins-style pass / fail / running). Konflux reports pipeline status as **GitHub Checks** (Checks tab), not GitHub Actions. There is no official GitHub URL that renders a Checks badge image.
+
+Today, users must open the Konflux UI (SSO) or the GitHub Checks popup to see status. We want a **single dynamic URL** per repo that README can embed for **build**, **Enterprise Contract (EC)**, and later **Ring / release** data.
+
+Beyond README badges, the same service can power **monitoring dashboards**, **portfolio status pages**, and **third-party integrations** (Slack bots, Jira, Confluence) via a JSON endpoint.
+
+### Spike findings
+
+We evaluated options and measured real repositories (`konflux-ci/konflux-ci`, `konflux-ci/segment-bridge`).
+
+| Approach | Tested | Verdict | Why |
+|---|---|---|---|
+| Shields.io `github/check-runs` | Live URLs + [source](https://github.com/badges/shields/blob/master/services/github/github-check-runs.service.js) | **Rejected** | Reads only first ~30 check-run rows. Busy repos have 50–70+; Konflux `*-on-push` often at row 31+ → `no check runs`. Third-party SaaS; weak for private repos. |
+| GitHub Action → commit `badge/*.svg` | Prototype workflow | **Rejected** | Mixes CI status into source; per-repo maintenance; org-wide pattern needs ADR anyway. |
+| Tekton task → git push SVG | Design review | **Rejected** | Same concerns as git-commit approach. |
+| Self-hosted Shields (`check-runs`) | Code review | **Rejected** | Same 30-row limit unless forked. Self-host helps RH control, not pagination. |
+| **Spike CLI: paginated Checks → SVG** | `go run` against segment-bridge | **Works** | Proves data + render logic; basis for service design. |
+
+### Constraints
+
+- README is rendered by GitHub — badge URL must be **reachable without user SSO** (public HTTPS or designed private-repo auth).
+- Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional but have established precedent (Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md), PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), registration-service). The [architecture overview](../architecture/index.md) permits these exceptions when justified.
+- Check runs are the status entries visible on each commit's **Checks tab** — the `-on-push` pipelines and `enterprise-contract` checks that PaC reports back to GitHub.
+- Check names are **per-component** (`*-on-push`, `*enterprise-contract*`), not one org-wide GitHub check name.
+- **Ring / release** status is not fully on GitHub Checks — requires cluster data (Tekton Results, Release CRs) later.
+- Konflux runs on **multiple production clusters**, and tenants from the same GitHub organization may be spread across different clusters.
+
+## Decision
+
+Introduce a **Konflux Badge Service** — a new **read-only HTTP service** (hosted in its own repository, e.g. `konflux-ci/badge-service`) that:
+
+1. Exposes **dynamic badge URLs** for onboarded repositories.
+2. Returns **SVG badge images** for README embedding and **JSON** for programmatic consumers.
+3. Uses the **paginated GitHub Checks API** initially for **build** and **EC** status on a branch HEAD.
+4. Extends later to **Tekton Results / Konflux CRs** for Ring and richer status, within the same codebase.
+5. Uses a **server-side GitHub credential** (GitHub App installation token stored in a Kubernetes Secret).
+
+### API shape
+
+```
+GET /badge/{githubOrg}/{githubRepo}/{branch}/build      → image/svg+xml
+GET /badge/{githubOrg}/{githubRepo}/{branch}/ec         → image/svg+xml
+GET /badge/{githubOrg}/{githubRepo}/{branch}/build.json → application/json
+GET /badge/{githubOrg}/{githubRepo}/{branch}/ec.json    → application/json
+```
+
+The **SVG endpoints** return badge images for README embedding. The **JSON endpoints** return structured status data for programmatic consumers:
+
+```json
+{
+  "org": "konflux-ci",
+  "repo": "build-service",
+  "branch": "main",
+  "type": "build",
+  "status": "passing",
+  "sha": "abc123...",
+  "updated": "2026-08-12T10:30:00Z"
+}
+```
+
+- **Data path**: resolve branch HEAD SHA → paginate `GET /repos/{org}/{repo}/commits/{sha}/check-runs` → aggregate `*-on-push` / `enterprise-contract` → pass | fail | running.
+- **Rendering**: `badge-maker` library ([MIT OR Apache-2.0](https://github.com/badges/shields/tree/master/badge-maker)) or equivalent minimal SVG — **not** shields.io SaaS `check-runs` route.
+- **No tenant resolution needed initially**: The data source is the GitHub API, not cluster-internal data. The service only needs the GitHub org, repo, and branch to query check runs.
+
+### README usage
+
+```markdown
+![Konflux build](https://<badge-host>/badge/{org}/{repo}/main/build)
+```
+
+### Security and auth model
+
+**Data exposure**: The endpoints expose **only aggregated pass / fail / running status**. No build logs, error messages, pipeline details, or secrets are returned. For public repositories, this status is already visible on GitHub's Checks tab without authentication, so the badge service does not increase the exposure surface. The badge endpoint is intentionally **unauthenticated** because GitHub's markdown renderer fetches badge images as an anonymous HTTP client. The architecture guidance to use `SubjectAccessReview` for exceptional HTTP endpoints does not apply here; that mechanism is for authenticated cluster API access. Phase 3 cluster data queries will use SAR-guarded access when reading Tekton Results or Release CRs.
+
+**GitHub credential**: The service authenticates to the GitHub API using the **existing PaC GitHub App** on its hosting cluster ([Pipeline Service docs](../architecture/core/pipeline-service.md), [ADR-0039](0039-workspace-deprecation.md), [ADR-0009](0009-pipeline-service-via-operator.md)). Each Konflux cluster registers a separate GitHub App ([ADR-0039](0039-workspace-deprecation.md)); the badge service reads that cluster's App credentials (stored as a Kubernetes Secret). That App already has `checks:read` permission. No new GitHub App installation is required.
+
+**Public endpoint protection**:
+
+- **Rate limiting**: per-IP rate limiting (e.g. 60 requests/minute per IP) at the ingress level.
+- **No secrets in URLs**: badge URLs contain only the GitHub org, repo, and branch — information that is already public for public repositories.
+
+**Private repositories**: GitHub's image renderer cannot fetch badges for private repos (it makes an anonymous GET). Initially, private repo badges return a neutral "private" shield or a 404. Users of private repos can use the `.json` endpoint from authenticated contexts instead. A future signed-URL-with-TTL scheme could address this but requires further design.
+
+### Caching and GitHub API rate limits
+
+GitHub App installation tokens have a rate limit of [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) per installation. Without caching, a popular repo's badge could exhaust this budget quickly.
+
+**Caching strategy**:
+
+- The service caches the computed badge result per `{org}/{repo}/{branch}/{type}` with a **TTL of 30–60 seconds**. Badge status may lag real-time by up to one minute, which is acceptable for README display.
+- Cache invalidation is TTL-based initially. A future enhancement could use GitHub webhooks (`check_suite` events) for near-real-time invalidation.
+- SVG responses include `Cache-Control: no-cache, no-store` headers to prevent GitHub's [camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) from serving stale images.
+
+**Rate budget**: With a 60-second cache TTL, each unique `{org}/{repo}/{branch}/{type}` key generates at most 120 GitHub API calls per hour (60 cache refreshes × 2 calls per refresh: resolve HEAD SHA + paginated check-runs). A single GitHub App installation (5,000 requests/hour) therefore supports roughly **40 badge keys** (~20 repos × 2 badge types) under sustained worst-case load. At a 30-second TTL, the budget halves to ~20 keys (~10 repos). README traffic is typically bursty and lower than this worst case, but cache TTL and the number of onboarded repos must be sized to stay within the per-installation limit.
+
+### Deployment model
+
+**Initial deployment: single instance on one cluster.** Since the data source is the GitHub Checks API, the badge service does not need access to tenant namespaces for Phase 1. It deploys as a Deployment on a single Konflux cluster, reading that cluster's PaC GitHub App credentials. A Kubernetes Ingress or Route exposes it at a public URL. It serves badges only for repos where **its hosting cluster's** PaC GitHub App is installed and has `checks:read` access. Repos whose tenants are onboarded on other clusters use a different GitHub App per [ADR-0039](0039-workspace-deprecation.md); those repos require a badge service instance (or equivalent routing) on the cluster that owns that App installation.
+
+**Evolution for cluster data sources.** When the service extends to read Tekton Results or Release CRs, it will need access to cluster-internal APIs. The deployment model evolves within the same codebase — new data source implementations are added. Two routing options exist:
+
+1. **Per-cluster instances** behind a routing layer that directs requests to the correct cluster based on an org/repo → cluster mapping (derivable from the platform's tenant onboarding configuration).
+2. **Central service** that queries Tekton Results APIs on remote clusters via their existing HTTP ingresses.
+
+This decision is deferred because it depends on which cluster data sources are needed and how they expose their APIs.
+
+### Rollout
+
+**Phase 1 — GitHub Checks badges**:
+1. Deploy the badge service on one Konflux cluster.
+2. The service accepts any `{org}/{repo}` for which **its hosting cluster's** PaC GitHub App has installation access. No per-repo onboarding configuration is needed.
+3. Support `build` and `ec` badge types (SVG and JSON).
+4. Private repos get a neutral "private" badge.
+5. Validate caching, rate limits, and SVG rendering in production.
+
+**Phase 2 — Broader adoption**:
+1. Promote the JSON endpoint for dashboard and monitoring use cases.
+2. Consider webhook-based cache invalidation for near-real-time badge updates.
+
+**Phase 3 — Cluster data sources**:
+1. Extend to read Tekton Results for richer status (pipeline duration, last N runs).
+2. Extend to read Release CRs for ring/release badges.
+3. Evolve the deployment model to support cluster-internal data access (see Deployment model section).
+4. Introduce tenant resolution (org/repo → cluster/namespace mapping) for cluster queries.
+
+## Alternatives Considered
+
+| Alternative | Verdict | Rationale |
+|---|---|---|
+| Shields.io SaaS only | **Rejected** | Low effort but fails at scale (pagination, third party, private repos). |
+| Per-repo GitHub Action publisher | **Rejected** | Technically viable; CI status in git plus N workflows to maintain is not org-scalable. |
+| Konflux UI deep-link only | **Insufficient** | Meets "see status" but not embeddable badge — does not satisfy stated product goal. |
+| Self-hosted Shields (`check-runs`) | **Rejected** | Does not fix pagination without a fork. Acceptable only as renderer (`endpoint?url=<our JSON>`); direct SVG is simpler. |
+| Deploy per-cluster from the start | **Deferred** | Unnecessary for GitHub-only data path. Adds deployment complexity without benefit until the service reads cluster-internal data. |
+| Extend Tekton Results with a badge endpoint | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge logic there is out of scope. It also uses Bearer token auth, incompatible with GitHub's anonymous image fetching. |
+| JSON-only service + self-hosted Shields for SVG | **Rejected** | Requires deploying two services. Since `badge-maker` handles SVG rendering trivially, a single service serving both JSON and SVG is simpler to operate. |
+
+## Consequences
+
+### Positive
+
+- One **org-standard** badge URL pattern for all onboarded repos.
+- **No git noise** — status stays outside source control.
+- **Paginated** GitHub access — fixes Shields 30-row limit.
+- **Extensible** to Ring/release via cluster APIs without changing README embed pattern.
+- Spike CLI logic maps directly to service handlers.
+- **Broader utility**: the JSON endpoint enables dashboards, Slack integrations, and portfolio views.
+- **Simple initial deployment**: single instance on one cluster, reusing PaC's existing GitHub App credentials.
+- **Follows established precedent**: public HTTP endpoints exist in Konflux (Tekton Results, PaC webhook receiver, registration-service).
+
+### Negative / compromises
+
+- **New operational component**: deploy, monitor, rate-limit, and secure a public HTTP endpoint.
+- **Private repo limitation**: badges unavailable for private repos until a signed-URL scheme is designed.
+- **Cache staleness**: badge status may lag real-time by up to 60 seconds.
+- **GitHub API rate limit**: each GitHub App installation supports a finite number of repos at a given cache TTL (see Caching section). Multi-cluster deployments need one badge service per cluster (or per GitHub App installation).
+- **GitHub API dependency**: if GitHub is down or rate-limited, badges degrade to a "status unknown" state.
+- **Deployment model must evolve**: adding cluster-internal data sources requires per-cluster deployment or a routing layer, which will need its own design work.
+- **Exceptional HTTP endpoint**: adds another exception to the "kube API server is the API server" constraint, justified by the use case and mitigated by the read-only, minimal-data nature of the endpoint.
+
+## References
+
+- [Architecture overview — constraints on HTTP endpoints](../architecture/index.md)
+- [Pipeline Service — Tekton Results ingress and GitHub App](../architecture/core/pipeline-service.md)
+- [ADR-0009 Pipeline Service via Operator](0009-pipeline-service-via-operator.md) — Tekton/PaC deployment model
+- [ADR-0039 Workspace Deprecation — per-cluster GitHub App model](0039-workspace-deprecation.md)
+- [GitHub Apps rate limits](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) — 5,000 requests/hour per installation
+- [badge-maker library](https://github.com/badges/shields/tree/master/badge-maker) — MIT/Apache-2.0 SVG generation
+- [GitHub camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — how GitHub proxies images in README files

--- a/ADR/0073-readme-status-badges.md
+++ b/ADR/0073-readme-status-badges.md
@@ -122,15 +122,11 @@ The **SVG endpoints** return badge images for README embedding. The **JSON endpo
 
 ### Caching and GitHub API rate limits
 
-GitHub App installation tokens have a rate limit of [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) per installation. Without caching, a popular repo's badge could exhaust this budget quickly.
+The [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) limit is **per GitHub App installation**, **shared with PaC** (check runs, webhooks, PR comments, etc.). Badge service must monitor `X-RateLimit-Remaining` and back off.
 
-**Caching strategy**:
-
-- The service caches the computed badge result per `{org}/{repo}/{branch}/{type}` with a **TTL of 30–60 seconds**. Badge status may lag real-time by up to one minute, which is acceptable for README display.
-- Cache invalidation is TTL-based initially. A future enhancement could use GitHub webhooks (`check_suite` events) for near-real-time invalidation.
-- SVG responses include `Cache-Control: no-cache, no-store` headers to prevent GitHub's [camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) from serving stale images.
-
-**Rate budget**: With a 60-second cache TTL, each unique `{org}/{repo}/{branch}/{type}` key generates at most 120 GitHub API calls per hour (60 cache refreshes × 2 calls per refresh: resolve HEAD SHA + paginated check-runs). A single GitHub App installation (5,000 requests/hour) therefore supports roughly **40 badge keys** (~20 repos × 2 badge types) under sustained worst-case load. At a 30-second TTL, the budget halves to ~20 keys (~10 repos). README traffic is typically bursty and lower than this worst case, but cache TTL and the number of onboarded repos must be sized to stay within the per-installation limit.
+- Cache badge results per `{org}/{repo}/{branch}/{type}` (TTL 30–60s).
+- Cache `repo.private` (~15 min).
+- At 60s TTL, ~120 GitHub calls/hour per badge key. If ~3,000/hour is used by PaC, ~16 badge keys (~8 repos × 2 types) fit in the remainder under sustained load. Size TTL and repo count to **remaining** quota.
 
 ### Deployment model
 
@@ -191,7 +187,7 @@ This decision is deferred because it depends on which cluster data sources are n
 - **New operational component**: deploy, monitor, rate-limit, and secure a public HTTP endpoint.
 - **Private repo limitation**: badges unavailable for private repos until a signed-URL scheme is designed.
 - **Cache staleness**: badge status may lag real-time by up to 60 seconds.
-- **GitHub API rate limit**: each GitHub App installation supports a finite number of repos at a given cache TTL (see Caching section). Multi-cluster deployments need one badge service per cluster (or per GitHub App installation).
+- **Shared GitHub API rate limit**: badge service competes with PaC for the same 5,000/hour per installation; must monitor remaining quota and size cache TTL accordingly.
 - **GitHub API dependency**: if GitHub is down or rate-limited, badges degrade to a "status unknown" state.
 - **Deployment model must evolve**: adding cluster-internal data sources requires per-cluster deployment or a routing layer, which will need its own design work.
 - **Exceptional HTTP endpoint**: adds another exception to the "kube API server is the API server" constraint, justified by the use case and mitigated by the read-only, minimal-data nature of the endpoint.
@@ -202,6 +198,6 @@ This decision is deferred because it depends on which cluster data sources are n
 - [Pipeline Service — Tekton Results ingress and GitHub App](../architecture/core/pipeline-service.md)
 - [ADR-0009 Pipeline Service via Operator](0009-pipeline-service-via-operator.md) — Tekton/PaC deployment model
 - [ADR-0039 Workspace Deprecation — per-cluster GitHub App model](0039-workspace-deprecation.md)
-- [GitHub Apps rate limits](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) — 5,000 requests/hour per installation
+- [GitHub Apps rate limits](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) — 5,000 requests/hour per installation (shared)
 - [badge-maker library](https://github.com/badges/shields/tree/master/badge-maker) — MIT/Apache-2.0 SVG generation
 - [GitHub camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — how GitHub proxies images in README files

--- a/ADR/0073-readme-status-badges.md
+++ b/ADR/0073-readme-status-badges.md
@@ -31,7 +31,7 @@ Beyond README badges, the same service can power **monitoring dashboards**, **po
 ### Constraints
 
 - README is rendered by GitHub — badge URL must be **reachable over public HTTPS**.
-- Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional but have established precedent (Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md), PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), registration-service). The [architecture overview](../architecture/index.md) permits these exceptions when justified.
+- Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional. The [architecture overview](../architecture/index.md) distinguishes two precedents: endpoints that expose **user/tenant cluster data** (e.g. Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md)) require **SubjectAccessReviews** for consistent RBAC; **unauthenticated supporting endpoints** that do not expose tenant data (PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), sprayproxy, registration-service) follow a separate precedent. **Phases 1–2** read public GitHub Checks data only — same category as the latter.
 - Check runs are the status entries visible on each commit's **Checks tab** — the `-on-push` pipelines and `enterprise-contract` checks that PaC reports back to GitHub.
 - Check names are **per-component** (`*-on-push`, `*enterprise-contract*`), not one org-wide GitHub check name.
 - **Ring / release** status is not fully on GitHub Checks — requires cluster data (Tekton Results, Release CRs) later.
@@ -72,7 +72,7 @@ sequenceDiagram
     GH-->>Viewer: Render badge
 ```
 
-**Public vs private (one URL, different response):** the service reads `repo.private` from the GitHub API. **Public** → fetch check runs, return real status SVG/JSON. **Private** → unauthenticated SVG returns a neutral badge only (no pass/fail); real status stays on GitHub Checks (for users with repo access). Returning real status for private repos on an open URL would let anyone who knows `org/repo/branch` learn build health without repo access.
+**Public vs private (one URL, different response):** the service reads `repo.private` from the GitHub API (cached ~15 min). **Public** → fetch check runs, return real status SVG/JSON. **Private** → requests without a valid signature get a neutral badge only (Phase 1). Phase 2 adds an HMAC query parameter for private README embeds (see below). **Fail-closed:** if repo visibility cannot be determined (API failure, rate limiting, cache miss with no response), return a **neutral badge** — never assume public.
 
 ### API shape
 
@@ -83,7 +83,7 @@ GET /badge/{githubOrg}/{githubRepo}/{branch}/build.json → application/json
 GET /badge/{githubOrg}/{githubRepo}/{branch}/ec.json    → application/json
 ```
 
-The **SVG endpoints** return badge images for README embedding. The **JSON endpoints** return structured status data for programmatic consumers:
+JSON response example (public repo, or private repo with valid `sig` in Phase 2):
 
 ```json
 {
@@ -97,7 +97,7 @@ The **SVG endpoints** return badge images for README embedding. The **JSON endpo
 }
 ```
 
-- **Data path**: resolve branch HEAD SHA → paginate `GET /repos/{org}/{repo}/commits/{sha}/check-runs` → aggregate `*-on-push` / `enterprise-contract` → pass | fail | running.
+- **Data path**: resolve branch HEAD SHA → paginate `GET /repos/{org}/{repo}/commits/{sha}/check-runs` → aggregate `*-on-push` / `enterprise-contract` → pass | fail | running | **unknown** (no matching check runs, e.g. newly onboarded or unconfigured branch).
 - **Rendering**: `badge-maker` library ([MIT OR Apache-2.0](https://github.com/badges/shields/tree/master/badge-maker)) or equivalent minimal SVG — **not** shields.io SaaS `check-runs` route.
 - **No tenant resolution needed initially**: The data source is the GitHub API, not cluster-internal data. The service only needs the GitHub org, repo, and branch to query check runs.
 
@@ -109,28 +109,34 @@ The **SVG endpoints** return badge images for README embedding. The **JSON endpo
 
 ### Security and auth model
 
-**Data exposure**: The endpoints expose **only aggregated pass / fail / running status**. No build logs, error messages, pipeline details, or secrets are returned. For public repositories, this status is already visible on GitHub's Checks tab without authentication, so the badge service does not increase the exposure surface. The badge endpoint is intentionally **unauthenticated** because GitHub's markdown renderer fetches badge images as an anonymous HTTP client. The architecture guidance to use `SubjectAccessReview` for exceptional HTTP endpoints does not apply here; that mechanism is for authenticated cluster API access. Phase 3 cluster data queries will use SAR-guarded access when reading Tekton Results or Release CRs.
+**GitHub credential**: reuses the **PaC GitHub App** on the hosting cluster ([Pipeline Service](../architecture/core/pipeline-service.md), [ADR-0039](0039-workspace-deprecation.md), [ADR-0009](0009-pipeline-service-via-operator.md)). No new App installation required.
 
-**GitHub credential**: The service authenticates to the GitHub API using the **existing PaC GitHub App** on its hosting cluster ([Pipeline Service docs](../architecture/core/pipeline-service.md), [ADR-0039](0039-workspace-deprecation.md), [ADR-0009](0009-pipeline-service-via-operator.md)). Each Konflux cluster registers a separate GitHub App ([ADR-0039](0039-workspace-deprecation.md)); the badge service reads that cluster's App credentials (stored as a Kubernetes Secret). That App already has `checks:read` permission. No new GitHub App installation is required.
+**Exposure**: SVG endpoint is unauthenticated (required for README/camo). Returns pass/fail/running for **public** repos only; **private** repos get a neutral SVG. No logs, secrets, or pipeline details. Phase 3 cluster reads will use SAR-guarded access.
 
-**Public endpoint protection**:
+**Protection**: per-IP rate limiting at ingress; public badge URLs contain only org/repo/branch.
 
-- **Rate limiting**: per-IP rate limiting (e.g. 60 requests/minute per IP) at the ingress level.
-- **No secrets in URLs**: badge URLs contain only the GitHub org, repo, and branch — information that is already public for public repositories.
+### Phase 2 — Private repository access (planned)
 
-**Private repositories**: GitHub's image renderer cannot fetch badges for private repos (it makes an anonymous GET). Initially, private repo badges return a neutral "private" shield or a 404. Users of private repos can use the `.json` endpoint from authenticated contexts instead. A future signed-URL-with-TTL scheme could address this but requires further design.
+Private README badges cannot use `Authorization` headers (camo sends a plain GET). Phase 2 adds an **HMAC signature** on the existing URL:
+
+```
+GET /badge/{org}/{repo}/{branch}/build?sig=<hmac>
+```
+
+The service verifies `sig` against a cluster signing secret (`HMAC(secret, org/repo/branch/type)`). Valid signature on a private repo → return real status; missing or invalid → neutral badge (same as Phase 1). Signatures are **not short-lived** (README markdown is static). Konflux UI or CLI generates the signed URL when the user copies embed markdown. Rotating the signing secret invalidates all existing signed badge URLs; users must re-copy embed markdown.
 
 ### Caching and GitHub API rate limits
 
-The [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) limit is **per GitHub App installation**, **shared with PaC** (check runs, webhooks, PR comments, etc.). Badge service must monitor `X-RateLimit-Remaining` and back off.
+The [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) limit is **per GitHub App installation**, **shared with PaC** (check runs, webhooks, PR comments, etc.) **and MintMaker** (dependency update scans via the same App token — see [MintMaker](../architecture/add-ons/mintmaker.md)). MintMaker is already rate-limited on some installations. Badge service must be the **lowest-priority consumer**: monitor `X-RateLimit-Remaining` and back off before PaC or MintMaker are affected.
 
-- Cache badge results per `{org}/{repo}/{branch}/{type}` (TTL 30–60s).
+- Cache badge results per `{org}/{repo}/{branch}/{type}` (TTL 30–60s; increase to several minutes if remaining quota is low).
 - Cache `repo.private` (~15 min).
-- At 60s TTL, ~120 GitHub calls/hour per badge key. If ~3,000/hour is used by PaC, ~16 badge keys (~8 repos × 2 types) fit in the remainder under sustained load. Size TTL and repo count to **remaining** quota.
+- When GitHub rate limit is exhausted or the service backs off to protect PaC/MintMaker quota, return a **neutral badge** (no status) — do not serve stale or guessed status.
+- At 60s TTL, ~120 GitHub calls/hour per badge key. At 5-min TTL, ~12 calls/hour — significantly reducing pressure. Size TTL and repo count to **remaining** quota.
 
 ### Deployment model
 
-**Initial deployment: single instance on one cluster.** Since the data source is the GitHub Checks API, the badge service does not need access to tenant namespaces for Phase 1. It deploys as a Deployment on a single Konflux cluster, reading that cluster's PaC GitHub App credentials. A Kubernetes Ingress or Route exposes it at a public URL. It serves badges only for repos where **its hosting cluster's** PaC GitHub App is installed and has `checks:read` access. Repos whose tenants are onboarded on other clusters use a different GitHub App per [ADR-0039](0039-workspace-deprecation.md); those repos require a badge service instance (or equivalent routing) on the cluster that owns that App installation.
+**Phase 1 requirements: a GitHub App token and a public HTTPS endpoint.** The badge service does not need access to tenant namespaces or cluster-internal APIs for Phase 1. It can run on **any Kubernetes cluster** (or equivalent runtime) that has the GitHub App credentials and a publicly reachable ingress. The service serves badges only for repos where the configured GitHub App is installed and has `checks:read` access. In multi-cluster Konflux installations, each cluster has its own GitHub App per [ADR-0039](0039-workspace-deprecation.md); repos onboarded on different clusters require a badge service instance (or routing) per App installation.
 
 **Evolution for cluster data sources.** When the service extends to read Tekton Results or Release CRs, it will need access to cluster-internal APIs. The deployment model evolves within the same codebase — new data source implementations are added. Two routing options exist:
 
@@ -145,12 +151,12 @@ This decision is deferred because it depends on which cluster data sources are n
 1. Deploy the badge service on one Konflux cluster.
 2. The service accepts any `{org}/{repo}` for which **its hosting cluster's** PaC GitHub App has installation access. No per-repo onboarding configuration is needed.
 3. Support `build` and `ec` badge types (SVG and JSON).
-4. Private repos get a neutral "private" badge.
+4. Private repos: neutral SVG and JSON (no status until Phase 2 `sig`).
 5. Validate caching, rate limits, and SVG rendering in production.
 
-**Phase 2 — Broader adoption**:
-1. Promote the JSON endpoint for dashboard and monitoring use cases.
-2. Consider webhook-based cache invalidation for near-real-time badge updates.
+**Phase 2 — Private repo badges**:
+1. Verify HMAC `sig` query param on existing badge URLs for private repos.
+2. Konflux UI or CLI generates signed embed markdown for private repos.
 
 **Phase 3 — Cluster data sources**:
 1. Extend to read Tekton Results for richer status (pipeline duration, last N runs).
@@ -168,6 +174,10 @@ This decision is deferred because it depends on which cluster data sources are n
 | Deploy per-cluster from the start | Design review | **Deferred** | Unnecessary for GitHub-only data path. Adds deployment complexity without benefit until the service reads cluster-internal data. |
 | Extend Tekton Results with a badge endpoint | Design review | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge logic there is out of scope. Bearer token auth incompatible with GitHub's anonymous image fetching. Badge service reads GitHub Checks (reported by PaC), not raw PipelineRun results. |
 | JSON-only service + self-hosted Shields for SVG | Design review | **Rejected** | Requires deploying two services. `badge-maker` renders SVG trivially; single service serving both JSON and SVG is simpler to operate. |
+| Opaque token registry (`/badge/t/{token}`) | Design review | **Rejected** | Requires per-badge storage and CRD; HMAC on existing URL is simpler. |
+
+
+
 
 ## Consequences
 
@@ -179,16 +189,17 @@ This decision is deferred because it depends on which cluster data sources are n
 - **Extensible** to Ring/release via cluster APIs without changing README embed pattern.
 - Spike CLI logic maps directly to service handlers.
 - **Broader utility**: the JSON endpoint enables dashboards, Slack integrations, and portfolio views.
-- **Simple initial deployment**: single instance on one cluster, reusing PaC's existing GitHub App credentials.
+- **Simple initial deployment**: single instance on any cluster with a GitHub App token and public ingress.
 - **Follows established precedent**: public HTTP endpoints exist in Konflux (Tekton Results, PaC webhook receiver, registration-service).
+- **Private-repo safety**: neutral badge avoids status leakage on unauthenticated SVG endpoint.
 
 ### Negative / compromises
 
 - **New operational component**: deploy, monitor, rate-limit, and secure a public HTTP endpoint.
-- **Private repo limitation**: badges unavailable for private repos until a signed-URL scheme is designed.
+- **Private repo README badges show no status** in Phase 1 (neutral badge only). Most onboarded repos may be private; primary value for them is JSON behind auth and Checks tab (unchanged).
 - **Cache staleness**: badge status may lag real-time by up to 60 seconds.
-- **Shared GitHub API rate limit**: badge service competes with PaC for the same 5,000/hour per installation; must monitor remaining quota and size cache TTL accordingly.
-- **GitHub API dependency**: if GitHub is down or rate-limited, badges degrade to a "status unknown" state.
+- **Shared GitHub API rate limit**: badge service competes with PaC and MintMaker for the same 5,000/hour per installation; must be the lowest-priority consumer and back off first.
+- **GitHub API dependency**: if GitHub is down, rate-limited, or repo visibility cannot be determined, badges degrade to a **neutral badge** (no status).
 - **Deployment model must evolve**: adding cluster-internal data sources requires per-cluster deployment or a routing layer, which will need its own design work.
 - **Exceptional HTTP endpoint**: adds another exception to the "kube API server is the API server" constraint, justified by the use case and mitigated by the read-only, minimal-data nature of the endpoint.
 

--- a/ADR/0073-readme-status-badges.md
+++ b/ADR/0073-readme-status-badges.md
@@ -4,9 +4,9 @@ status: Proposed
 applies_to:
   - pipeline-service
 topics:
-  - github-integration
+  - tekton-results
   - badges
-  - external-api
+  - cluster-data
   - observability
 ---
 
@@ -24,191 +24,197 @@ Proposed
 
 Teams want **embeddable build status** on the default branch README (Jenkins-style pass / fail / running). Konflux reports pipeline status as **GitHub Checks** (Checks tab), not GitHub Actions. There is no official GitHub URL that renders a Checks badge image.
 
-Today, users must open the Konflux UI (SSO) or the GitHub Checks popup to see status. We want a **single dynamic URL** per repo that README can embed for **build**, **Enterprise Contract (EC)**, and later **Ring / release** data.
-
-Beyond README badges, the same service can power **monitoring dashboards**, **portfolio status pages**, and **third-party integrations** (Slack bots, Jira, Confluence) via a JSON endpoint.
+Today, users must open the Konflux UI (SSO) or the GitHub Checks popup to see status. We want a **dynamic badge URL** per repository that README can embed for **build**, **Enterprise Contract (EC)**, and **release** data.
 
 ### Constraints
 
 - README is rendered by GitHub — badge URL must be **reachable over public HTTPS**.
-- Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional. The [architecture overview](../architecture/index.md) distinguishes two precedents: endpoints that expose **user/tenant cluster data** (e.g. Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md)) require **SubjectAccessReviews** for consistent RBAC; **unauthenticated supporting endpoints** that do not expose tenant data (PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), sprayproxy, registration-service) follow a separate precedent. **Phases 1–2** read public GitHub Checks data only — same category as the latter.
-- Check runs are the status entries visible on each commit's **Checks tab** — the `-on-push` pipelines and `enterprise-contract` checks that PaC reports back to GitHub.
-- Check names are **per-component** (`*-on-push`, `*enterprise-contract*`), not one org-wide GitHub check name.
-- **Ring / release** status is not fully on GitHub Checks — requires cluster data (Tekton Results, Release CRs) later.
+- Konflux primary API is **Kubernetes CRDs** ([architecture overview](https://konflux-ci.dev/architecture/)); user-facing HTTP endpoints are exceptional. The [architecture overview](../architecture/index.md) distinguishes two precedents: endpoints that expose **user/tenant cluster data** (e.g. Tekton Results ingress per [Pipeline Service](../architecture/core/pipeline-service.md) and [ADR-0009](0009-pipeline-service-via-operator.md)) require **SubjectAccessReviews** for consistent RBAC; **unauthenticated supporting endpoints** that do not expose tenant data (PaC webhook receiver per [ADR-0039](0039-workspace-deprecation.md), registration-service) follow a separate precedent. The badge service exposes **minimal derived status** (pass/fail/running) — no logs, secrets, or pipeline details.
 - Konflux runs on **multiple production clusters**, and tenants from the same GitHub organization may be spread across different clusters.
-- Konflux onboarding data (Component CRs, tenant config) records **git URLs** but not GitHub repository visibility (public vs private). The proportion of private onboarded repos is unknown without querying the GitHub API per repository.
+- [Pipelines as Code](https://pipelinesascode.com/docs/concepts/) already reports PipelineRun status to GitHub Checks by watching PipelineRun changes on the cluster. The **cluster is the source of truth** — GitHub Checks is a downstream consumer.
+- Pipelines as Code stamps every PipelineRun with metadata labels (`pipelinesascode.tekton.dev/url-org`, `url-repository`, `sha`, `event-type`, `state`) that make them queryable via Tekton Results.
 
 ## Decision
 
 Introduce a **Konflux Badge Service** — a new **read-only HTTP service** (hosted in its own repository, e.g. `konflux-ci/badge-service`) that:
 
 1. Exposes **dynamic badge URLs** for onboarded repositories.
-2. Returns **SVG badge images** for README embedding and **JSON** for programmatic consumers.
-3. Uses the **paginated GitHub Checks API** initially for **build** and **EC** status on a branch HEAD.
-4. Extends later to **Tekton Results / Konflux CRs** for Ring and richer status, within the same codebase.
-5. Uses a **server-side GitHub credential** (GitHub App installation token stored in a Kubernetes Secret).
+2. Returns **SVG badge images** for README embedding.
+3. Reads **Tekton Results** for build and EC status using a cluster-internal ServiceAccount.
+4. Reads **Release CRs** for release/ring badges.
+5. Deploys **per-cluster** — each badge service instance reads its own cluster's data.
 
 ### Data flow
 
-GitHub README images are fetched by GitHub's [camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — a plain HTTPS GET with **no viewer login** passed to the badge service. The badge service calls the GitHub API using the **PaC GitHub App** installation token (same App/credentials PaC uses to report check runs; stored in a cluster Secret).
+GitHub README images are fetched by GitHub's [camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — a plain HTTPS GET with **no viewer login** passed to the badge service. The badge service queries **Tekton Results** on the same cluster using a Kubernetes ServiceAccount with the `tekton-results-readonly` ClusterRole.
 
 ```mermaid
 sequenceDiagram
     participant Viewer
     participant GH as GitHub (README + camo)
-    participant Badge as Badge Service
-    participant GHAPI as GitHub API
+    participant Badge as Badge Service (per-cluster)
+    participant TR as Tekton Results API
 
     Viewer->>GH: Open README
-    GH->>Badge: GET /badge/{org}/{repo}/{branch}/build
-    Badge->>GHAPI: GET /repos/{org}/{repo} (App token)
-    GHAPI-->>Badge: private: true/false
-    alt public repo
-        Badge->>GHAPI: GET check-runs
-        Badge-->>GH: SVG (pass/fail/running)
-    else private repo
-        Badge-->>GH: SVG (neutral — no status)
-    end
+    GH->>Badge: GET /badge/.../{type}
+    Badge->>TR: Query PipelineRuns (ServiceAccount token)
+    TR-->>Badge: PipelineRun status + task results
+    Badge-->>GH: SVG (pass/fail/running)
     GH-->>Viewer: Render badge
 ```
 
-**Public vs private (one URL, different response):** the service reads `repo.private` from the GitHub API (cached ~15 min). **Public** → fetch check runs, return real status SVG/JSON. **Private** → requests without a valid signature get a neutral badge only (Phase 1). Phase 2 adds an HMAC query parameter for private README embeds (see below). **Fail-closed:** if repo visibility cannot be determined (API failure, rate limiting, cache miss with no response), return a **neutral badge** — never assume public.
+**Data path**: the badge service queries the Tekton Results REST API with a CEL filter on PaC labels (e.g. `data.metadata.labels['pipelinesascode.tekton.dev/url-org']`, `url-repository`, `event-type=='push'`), ordered by `create_time desc`, limited to the most recent run. It extracts the PipelineRun conclusion from `status.conditions` and optionally reads `TEST_OUTPUT` / `SCAN_OUTPUT` task results for richer badge content.
 
-### API shape
+### ServiceAccount and RBAC
+
+The badge service runs with a Kubernetes ServiceAccount in its own namespace, bound to the [`tekton-results-readonly` ClusterRole](https://github.com/tektoncd/results/blob/main/docs/api/README.md#authorization) — a role that **already exists** as part of the Tekton Results installation. The pod's token is automatically mounted and passed as `Authorization: Bearer <token>` to the Tekton Results REST API. The Results API authenticates via `TokenReview` and authorizes via `SubjectAccessReview` — the [standard Tekton Results auth model](https://github.com/tektoncd/results/blob/main/docs/api/README.md#authentication--authorization).
+
+**RBAC vs application security boundary**: the `tekton-results-readonly` ClusterRole grants read access to **all** Results records across all namespaces. The badge service intentionally returns only a derived status value (pass/fail/running) — the data reduction from full PipelineRun records to a single status string is enforced at the **application layer**, not by RBAC. If the badge service is compromised, the attacker gains read access to all Tekton Results data. Operators should weigh this when deploying and apply standard hardening (minimal container image, network policies restricting egress, pod security standards).
+
+### API shape — two URL scheme options
+
+Two URL schemes are viable. Both expose the same data; the choice affects privacy and operational complexity. **Deployers should choose the scheme that matches their privacy requirements.**
+
+#### Option A: Explicit namespace and component
 
 ```
-GET /badge/{githubOrg}/{githubRepo}/{branch}/build      → image/svg+xml
-GET /badge/{githubOrg}/{githubRepo}/{branch}/ec         → image/svg+xml
-GET /badge/{githubOrg}/{githubRepo}/{branch}/build.json → application/json
-GET /badge/{githubOrg}/{githubRepo}/{branch}/ec.json    → application/json
+GET /badge/{namespace}/{component}/build       → image/svg+xml
+GET /badge/{namespace}/{component}/ec           → image/svg+xml
 ```
 
-JSON response example (public repo, or private repo with valid `sig` in Phase 2):
-
-```json
-{
-  "org": "konflux-ci",
-  "repo": "build-service",
-  "branch": "main",
-  "type": "build",
-  "status": "passing",
-  "sha": "abc123...",
-  "updated": "2026-08-12T10:30:00Z"
-}
-```
-
-- **Data path**: resolve branch HEAD SHA → paginate `GET /repos/{org}/{repo}/commits/{sha}/check-runs` → aggregate `*-on-push` / `enterprise-contract` → pass | fail | running | **unknown** (no matching check runs, e.g. newly onboarded or unconfigured branch).
-- **Rendering**: `badge-maker` library ([MIT OR Apache-2.0](https://github.com/badges/shields/tree/master/badge-maker)) or equivalent minimal SVG — **not** shields.io SaaS `check-runs` route.
-- **No tenant resolution needed initially**: The data source is the GitHub API, not cluster-internal data. The service only needs the GitHub org, repo, and branch to query check runs.
-
-### README usage
+README usage:
 
 ```markdown
-![Konflux build](https://<badge-host>/badge/{org}/{repo}/main/build)
+![Konflux build](https://badges.cluster-a.example.com/badge/my-team-ns/my-service/build)
 ```
 
-### Security and auth model
+| Pros | Cons |
+|---|---|
+| No state or index required — the service queries Tekton Results directly by namespace | Namespace and component names are visible in the public README URL |
+| Simple to implement and debug | No access control — anyone who guesses or discovers the namespace/component can query the badge |
+| User can construct the URL without any UI or CLI 
 
-**GitHub credential**: reuses the **PaC GitHub App** on the hosting cluster ([Pipeline Service](../architecture/core/pipeline-service.md), [ADR-0039](0039-workspace-deprecation.md), [ADR-0009](0009-pipeline-service-via-operator.md)). No new App installation required.
-
-**Exposure**: SVG endpoint is unauthenticated (required for README/camo). Returns pass/fail/running for **public** repos only; **private** repos get a neutral SVG. No logs, secrets, or pipeline details. Phase 3 cluster reads will use SAR-guarded access.
-
-**Protection**: per-IP rate limiting at ingress; public badge URLs contain only org/repo/branch.
-
-### Phase 2 — Private repository access (planned)
-
-Private README badges cannot use `Authorization` headers (camo sends a plain GET). Phase 2 adds an **HMAC signature** on the existing URL:
+#### Option B: Opaque token
 
 ```
-GET /badge/{org}/{repo}/{branch}/build?sig=<hmac>
+GET /badge/{token}/build       → image/svg+xml
+GET /badge/{token}/ec           → image/svg+xml
 ```
 
-The service verifies `sig` against a cluster signing secret (`HMAC(secret, org/repo/branch/type)`). Valid signature on a private repo → return real status; missing or invalid → neutral badge (same as Phase 1). Signatures are **not short-lived** (README markdown is static). Konflux UI or CLI generates the signed URL when the user copies embed markdown. Rotating the signing secret invalidates all existing signed badge URLs; users must re-copy embed markdown.
+The `{token}` is a short random string (e.g. `k7x2mQ9p`) that maps to a specific namespace + component on that cluster. It is stored as an annotation on the Component CR:
 
-### Caching and GitHub API rate limits
+```yaml
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  name: my-service
+  namespace: my-team-ns
+  annotations:
+    badges.konflux.dev/token: "k7x2mQ9p"
+```
 
-The [5,000 requests/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) limit is **per GitHub App installation**, **shared with PaC** (check runs, webhooks, PR comments, etc.) **and MintMaker** (dependency update scans via the same App token — see [MintMaker](../architecture/add-ons/mintmaker.md)). MintMaker is already rate-limited on some installations. Badge service must be the **lowest-priority consumer**: monitor `X-RateLimit-Remaining` and back off before PaC or MintMaker are affected.
+README usage:
 
-- Cache badge results per `{org}/{repo}/{branch}/{type}` (TTL 30–60s; increase to several minutes if remaining quota is low).
-- Cache `repo.private` (~15 min).
-- When GitHub rate limit is exhausted or the service backs off to protect PaC/MintMaker quota, return a **neutral badge** (no status) — do not serve stale or guessed status.
-- At 60s TTL, ~120 GitHub calls/hour per badge key. At 5-min TTL, ~12 calls/hour — significantly reducing pressure. Size TTL and repo count to **remaining** quota.
+```markdown
+![Konflux build](https://badges.cluster-a.example.com/badge/k7x2mQ9p/build)
+```
+
+| Pros | Cons |
+|---|---|
+| Namespace and component names are never exposed in public URLs | Requires the badge service to watch Component CRs and maintain an in-memory token → (namespace, component) index |
+| Revoking access = remove the annotation; badge returns "unknown" | User must copy the badge URL from the Konflux UI or CLI — cannot construct it manually |
+| Token is meaningless without cluster access | Token generation mechanism needed (controller, UI action, or badge service itself on first request) |
+
+#### Common to both options
+
+- **Opt-in required**: both options require a `badges.konflux.dev/enabled: "true"` annotation on the Component CR. The badge service returns `unknown` for components that have not opted in. This prevents unauthenticated enumeration of namespace/component names or build status.
+- **Rendering**: `badge-maker` library ([MIT OR Apache-2.0](https://github.com/badges/shields/tree/master/badge-maker)) or equivalent minimal SVG — **not** shields.io SaaS.
+- **Status values**: `passing` | `failing` | `running` | `unknown` (no matching PipelineRun found, or badges not enabled).
+- **JSON endpoint**: once the SVG service exists, adding a `.json` variant for programmatic consumers (dashboards, Slack bots) is straightforward.
+
+### Security and privacy model
+
+**No GitHub API dependency**: the badge service does not call the GitHub API. It reads Tekton Results using a cluster-internal ServiceAccount. No GitHub App token, no shared rate limit.
+
+**Exposure**: the SVG endpoint is unauthenticated (required for GitHub camo). The badge returns only a **derived status** (pass/fail/running). No logs, secrets, pipeline YAML, or task details are exposed.
+
+**Opt-in only**: the badge service returns `unknown` for any component that does not have the `badges.konflux.dev/enabled` annotation. No status is exposed unless the component owner explicitly enables it. With Option B (opaque token), namespace and component names are never visible externally. With Option A, the user who enables and embeds the URL deliberately chose to expose those names.
+
+**Protection**: per-IP rate limiting at ingress; responses are minimal and cacheable.
+
+### Caching
+
+- Cache badge results per key (TTL 30–60s). Since the data source is cluster-internal, there is no external rate limit to worry about.
+- Use HTTP `ETag` headers for client-side cache validation (same approach as [Jenkins embeddable-build-status-plugin](https://github.com/jenkinsci/embeddable-build-status-plugin/blob/master/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java)).
+- Tekton Results queries are cheap (indexed, local network). The cache primarily reduces load on the Results API server, not works around external quotas.
 
 ### Deployment model
 
-**Phase 1 requirements: a GitHub App token and a public HTTPS endpoint.** The badge service does not need access to tenant namespaces or cluster-internal APIs for Phase 1. It can run on **any Kubernetes cluster** (or equivalent runtime) that has the GitHub App credentials and a publicly reachable ingress. The service serves badges only for repos where the configured GitHub App is installed and has `checks:read` access. In multi-cluster Konflux installations, each cluster has its own GitHub App per [ADR-0039](0039-workspace-deprecation.md); repos onboarded on different clusters require a badge service instance (or routing) per App installation.
+**Per-cluster deployment.** Each Konflux cluster runs its own badge service instance that reads its own Tekton Results API. This is the natural model because:
 
-**Evolution for cluster data sources.** When the service extends to read Tekton Results or Release CRs, it will need access to cluster-internal APIs. The deployment model evolves within the same codebase — new data source implementations are added. Two routing options exist:
+- Tekton Results is per-cluster (each cluster archives its own PipelineRuns).
+- Each cluster has its own public ingress for the badge service.
+- No cross-cluster routing or tenant resolution is needed — the badge URL's hostname identifies the cluster.
 
-1. **Per-cluster instances** behind a routing layer that directs requests to the correct cluster based on an org/repo → cluster mapping (derivable from the platform's tenant onboarding configuration).
-2. **Central service** that queries Tekton Results APIs on remote clusters via their existing HTTP ingresses.
+**Requirements**: a Kubernetes ServiceAccount with `tekton-results-readonly`, and a publicly reachable ingress (Route/Ingress).
 
-This decision is deferred because it depends on which cluster data sources are needed and how they expose their APIs.
+**Multi-cluster**: repos onboarded on different clusters use different badge service hostnames. The README author knows which cluster their component is on and uses the corresponding URL. If a unified hostname is needed later, a DNS-level or ingress-level routing layer can be added without changing the badge service itself.
 
 ### Rollout
 
-**Phase 1 — GitHub Checks badges**:
-1. Deploy the badge service on one Konflux cluster.
-2. The service accepts any `{org}/{repo}` for which **its hosting cluster's** PaC GitHub App has installation access. No per-repo onboarding configuration is needed.
-3. Support `build` and `ec` badge types (SVG and JSON).
-4. Private repos: neutral SVG and JSON (no status until Phase 2 `sig`).
-5. Validate caching, rate limits, and SVG rendering in production.
-
-**Phase 2 — Private repo badges**:
-1. Verify HMAC `sig` query param on existing badge URLs for private repos.
-2. Konflux UI or CLI generates signed embed markdown for private repos.
-
-**Phase 3 — Cluster data sources**:
-1. Extend to read Tekton Results for richer status (pipeline duration, last N runs).
-2. Extend to read Release CRs for ring/release badges.
-3. Evolve the deployment model to support cluster-internal data access (see Deployment model section).
-4. Introduce tenant resolution (org/repo → cluster/namespace mapping) for cluster queries.
+1. Deploy the badge service on one Konflux cluster with both URL scheme options implemented (operators choose which to enable).
+2. Support `build` and `ec` badge types (SVG).
+3. If using Option B, implement token generation (annotation on Component CR) via UI, CLI, or controller.
+4. Validate caching, SVG rendering, and Tekton Results query performance in production.
+5. Extend to read Release CRs for release/ring badges within the same codebase.
 
 ## Alternatives Considered
 
 | Alternative | Evaluated | Verdict | Rationale |
 |---|---|---|---|
+| **GitHub Checks API as primary data source** (original revision of this ADR) | Design review, prototype | **Rejected** | Circular data flow — reads data PaC already pushed from the cluster. Shares the GitHub App's [5,000 req/hour](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) quota with PaC and [MintMaker](../architecture/add-ons/mintmaker.md); requires complex backoff. Private repo handling required a phased HMAC scheme. Only covers build and EC badges — no release/ring status. GitHub-specific — does not work for GitLab-hosted repositories. |
 | Shields.io SaaS `github/check-runs` | Live URLs on `konflux-ci/konflux-ci`, `konflux-ci/segment-bridge`; [source review](https://github.com/badges/shields/blob/master/services/github/github-check-runs.service.js) | **Rejected** | Reads only first ~30 check-run rows. Busy repos have 50–70+; Konflux `*-on-push` often at row 31+ → `no check runs`. Third-party SaaS; weak for private repos. |
-| GitHub Action → commit `badge/*.svg` to repo | Prototype workflow | **Rejected** | Mixes CI status into source; per-repo maintenance; |
+| GitHub Action → commit `badge/*.svg` to repo | Prototype workflow | **Rejected** | Mixes CI status into source; per-repo maintenance. |
 | Tekton task → git push SVG | Design review | **Rejected** | Same concerns as git-commit approach. |
-| Deploy per-cluster from the start | Design review | **Deferred** | Unnecessary for GitHub-only data path. Adds deployment complexity without benefit until the service reads cluster-internal data. |
-| Extend Tekton Results with a badge endpoint | Design review | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge logic there is out of scope. Bearer token auth incompatible with GitHub's anonymous image fetching. Badge service reads GitHub Checks (reported by PaC), not raw PipelineRun results. |
-| JSON-only service + self-hosted Shields for SVG | Design review | **Rejected** | Requires deploying two services. `badge-maker` renders SVG trivially; single service serving both JSON and SVG is simpler to operate. |
-| Opaque token registry (`/badge/t/{token}`) | Design review | **Rejected** | Requires per-badge storage and CRD; HMAC on existing URL is simpler. |
-
-
-
+| Extend Tekton Results with a badge endpoint | Design review | **Rejected** | Tekton Results is an upstream project (`tektoncd/results`) — adding Konflux-specific badge/SVG logic is out of scope. The Results API requires Bearer token auth which is incompatible with GitHub camo's anonymous GET. A separate thin service that translates authenticated Results queries into unauthenticated SVG responses is the right separation. |
+| JSON-only service + self-hosted Shields for SVG | Design review | **Rejected** | Requires deploying two services. `badge-maker` renders SVG trivially; a single service serving both JSON and SVG is simpler to operate. |
+| Contribute badge endpoint to Pipelines as Code | Design review | **Rejected** | PaC is an upstream project focused on Git event processing and pipeline triggering. A badge endpoint is a different concern (read-only status rendering). PaC's [Repository CR stores only the last 5 PipelineRun statuses](https://pipelinesascode.com/docs/concepts/) — insufficient for historical queries. Separate service with separate lifecycle is cleaner. |
 
 ## Consequences
 
 ### Positive
 
-- One **org-standard** badge URL pattern for all onboarded repos.
+- **No external API dependency** — reads cluster-internal Tekton Results. No GitHub API rate limit concerns, no shared quota with PaC/MintMaker.
+- **Richer data from day one** — structured `TEST_OUTPUT` and `SCAN_OUTPUT` results, pipeline duration, Release CR status. Not limited to pass/fail.
+- One **org-standard** badge URL pattern for all onboarded repositories.
 - **No git noise** — status stays outside source control.
-- **Paginated** GitHub access — fixes Shields 30-row limit.
-- **Extensible** to Ring/release via cluster APIs without changing README embed pattern.
-- Spike CLI logic maps directly to service handlers.
-- **Broader utility**: the JSON endpoint enables dashboards, Slack integrations, and portfolio views.
-- **Simple initial deployment**: single instance on any cluster with a GitHub App token and public ingress.
+- **Git-provider agnostic** — works for GitHub and GitLab repositories alike; no dependency on provider-specific APIs.
 - **Follows established precedent**: public HTTP endpoints exist in Konflux (Tekton Results, PaC webhook receiver, registration-service).
-- **Private-repo safety**: neutral badge avoids status leakage on unauthenticated SVG endpoint.
+- **Follows Jenkins model**: serving badges from internal CI data is a proven pattern ([embeddable-build-status-plugin](https://github.com/jenkinsci/embeddable-build-status-plugin)).
+- **No private/public repo distinction needed** — the badge is tied to a Konflux namespace, not a GitHub repository. The user who embeds the URL controls visibility.
 
 ### Negative / compromises
 
-- **New operational component**: deploy, monitor, rate-limit, and secure a public HTTP endpoint.
-- **Private repo README badges show no status** in Phase 1 (neutral badge only). Most onboarded repos may be private; primary value for them is JSON behind auth and Checks tab (unchanged).
+- **New operational component**: deploy, monitor, and secure a public HTTP endpoint per cluster.
 - **Cache staleness**: badge status may lag real-time by up to 60 seconds.
-- **Shared GitHub API rate limit**: badge service competes with PaC and MintMaker for the same 5,000/hour per installation; must be the lowest-priority consumer and back off first.
-- **GitHub API dependency**: if GitHub is down, rate-limited, or repo visibility cannot be determined, badges degrade to a **neutral badge** (no status).
-- **Deployment model must evolve**: adding cluster-internal data sources requires per-cluster deployment or a routing layer, which will need its own design work.
-- **Exceptional HTTP endpoint**: adds another exception to the "kube API server is the API server" constraint, justified by the use case and mitigated by the read-only, minimal-data nature of the endpoint.
+- **Per-cluster URLs**: repos on different clusters use different badge service hostnames. A unified hostname requires additional routing infrastructure.
+- **New public HTTP endpoint**: architecturally this is a **read-only facade** over the existing Tekton Results HTTP API (which already has an ingress per [Pipeline Service](../architecture/core/pipeline-service.md)), translating authenticated Results queries into unauthenticated SVG responses. It does not introduce a new data path — it narrows an existing one.
+- **Option B (opaque token) adds operational complexity**: token generation, Component CR annotation management, and an in-memory index in the badge service.
+- **Cross-namespace read access**: the badge service ServiceAccount requires cluster-wide `tekton-results-readonly` — operators must be comfortable granting this. The service exposes only derived status (pass/fail), never raw PipelineRun content.
 
 ## References
 
 - [Architecture overview — constraints on HTTP endpoints](../architecture/index.md)
-- [Pipeline Service — Tekton Results ingress and GitHub App](../architecture/core/pipeline-service.md)
+- [Pipeline Service — Tekton Results ingress](../architecture/core/pipeline-service.md)
 - [ADR-0009 Pipeline Service via Operator](0009-pipeline-service-via-operator.md) — Tekton/PaC deployment model
+- [ADR-0030 Tekton Results Naming Convention](0030-tekton-results-naming-convention.md) — `TEST_OUTPUT` and `SCAN_OUTPUT` result formats
 - [ADR-0039 Workspace Deprecation — per-cluster GitHub App model](0039-workspace-deprecation.md)
-- [GitHub Apps rate limits](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) — 5,000 requests/hour per installation (shared)
+- [Tekton Results API documentation](https://tekton.dev/docs/results/api/) — REST/gRPC API with CEL filtering
+- [Tekton Results Watcher — PaC label propagation](https://tekton.dev/docs/results/watcher/) — how PipelineRun metadata is indexed
+- [Pipelines as Code — Concepts and status reporting](https://pipelinesascode.com/docs/concepts/) — how PaC reports status from cluster to GitHub Checks
+- [Pipelines as Code — PipelineRun labels](https://docs.pipelinesascode.com/v0.44.0/docs/concepts/) — `pipelinesascode.tekton.dev/url-org`, `url-repository`, `sha`, `event-type` labels on PipelineRuns
+- [Jenkins embeddable-build-status-plugin](https://github.com/jenkinsci/embeddable-build-status-plugin) — prior art for serving CI badges from internal data
+- [Jenkins StatusImage.java — SVG generation with ETag caching](https://github.com/jenkinsci/embeddable-build-status-plugin/blob/master/src/main/java/org/jenkinsci/plugins/badge/StatusImage.java)
 - [badge-maker library](https://github.com/badges/shields/tree/master/badge-maker) — MIT/Apache-2.0 SVG generation
 - [GitHub camo proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls) — how GitHub proxies images in README files
+- [GitHub Apps rate limits](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) — 5,000 requests/hour per installation (context for why the GitHub API approach was rejected)

--- a/ADR/AGENTS.md
+++ b/ADR/AGENTS.md
@@ -47,7 +47,7 @@ Status: Ac=Accepted Im=Implemented Ib=Implementable Pr=Proposed Ap=Approved Rp=R
 0016 Ss 107L Promotion logic in the Integration Service
 0042 Ac 259L Provisioning Clusters for Integration Tests
 0000 Im 31L Record architecture decisions
-0073 Pr 193L README Status Badges via Konflux Badge Service
+0073 Pr 207L README Status Badges via Konflux Badge Service
 0024 Ac 97L Release Objects Attribution Tracking and Propagation
 0071 Ac 275L Replace Appstudio Labels, Annotations, and Finalizers with Konflux equivalents
 0069 Pr 158L Reproducible Container Builds in Konflux

--- a/ADR/AGENTS.md
+++ b/ADR/AGENTS.md
@@ -47,7 +47,7 @@ Status: Ac=Accepted Im=Implemented Ib=Implementable Pr=Proposed Ap=Approved Rp=R
 0016 Ss 107L Promotion logic in the Integration Service
 0042 Ac 259L Provisioning Clusters for Integration Tests
 0000 Im 31L Record architecture decisions
-0073 Pr 207L README Status Badges via Konflux Badge Service
+0073 Pr 203L README Status Badges via Konflux Badge Service
 0024 Ac 97L Release Objects Attribution Tracking and Propagation
 0071 Ac 275L Replace Appstudio Labels, Annotations, and Finalizers with Konflux equivalents
 0069 Pr 158L Reproducible Container Builds in Konflux

--- a/ADR/AGENTS.md
+++ b/ADR/AGENTS.md
@@ -46,7 +46,7 @@ Status: Ac=Accepted Im=Implemented Ib=Implementable Pr=Proposed Ap=Approved Rp=R
 0034 Im 524L Project Controller for Multi-version support
 0016 Ss 107L Promotion logic in the Integration Service
 0042 Ac 259L Provisioning Clusters for Integration Tests
-0073 Pr 214L README Status Badges via Konflux Badge Service
+0073 Pr 220L README Status Badges via Konflux Badge Service
 0000 Im 31L Record architecture decisions
 0024 Ac 97L Release Objects Attribution Tracking and Propagation
 0071 Ac 275L Replace Appstudio Labels, Annotations, and Finalizers with Konflux equivalents

--- a/ADR/AGENTS.md
+++ b/ADR/AGENTS.md
@@ -46,8 +46,8 @@ Status: Ac=Accepted Im=Implemented Ib=Implementable Pr=Proposed Ap=Approved Rp=R
 0034 Im 524L Project Controller for Multi-version support
 0016 Ss 107L Promotion logic in the Integration Service
 0042 Ac 259L Provisioning Clusters for Integration Tests
+0073 Pr 214L README Status Badges via Konflux Badge Service
 0000 Im 31L Record architecture decisions
-0073 Pr 203L README Status Badges via Konflux Badge Service
 0024 Ac 97L Release Objects Attribution Tracking and Propagation
 0071 Ac 275L Replace Appstudio Labels, Annotations, and Finalizers with Konflux equivalents
 0069 Pr 158L Reproducible Container Builds in Konflux

--- a/ADR/AGENTS.md
+++ b/ADR/AGENTS.md
@@ -47,6 +47,7 @@ Status: Ac=Accepted Im=Implemented Ib=Implementable Pr=Proposed Ap=Approved Rp=R
 0016 Ss 107L Promotion logic in the Integration Service
 0042 Ac 259L Provisioning Clusters for Integration Tests
 0000 Im 31L Record architecture decisions
+0073 Pr 193L README Status Badges via Konflux Badge Service
 0024 Ac 97L Release Objects Attribution Tracking and Propagation
 0071 Ac 275L Replace Appstudio Labels, Annotations, and Finalizers with Konflux equivalents
 0069 Pr 158L Reproducible Container Builds in Konflux


### PR DESCRIPTION
Problem: Konflux reports status via GitHub Checks, but there’s no badge URL teams can embed in READMEs.

Solution: A read-only Konflux Badge Service that queries Tekton results and returns SVG badges, starting with build and EC status.